### PR TITLE
Human go/no-go feedback: implement the manual disposition workflow and persist machine-readable results (#982)

### DIFF
--- a/.github/workflows/human-go-no-go-feedback.yml
+++ b/.github/workflows/human-go-no-go-feedback.yml
@@ -1,0 +1,116 @@
+name: Human Go/No-Go Feedback
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_context:
+        description: 'Target work context identifier'
+        required: true
+        type: string
+      target_ref:
+        description: 'Target ref, branch, or execution surface'
+        required: true
+        type: string
+      decision:
+        description: 'Human disposition for the next iteration'
+        required: true
+        type: choice
+        options:
+          - go
+          - nogo
+      feedback:
+        description: 'Free-form human feedback for the next iteration'
+        required: true
+        type: string
+      related_issue_url:
+        description: 'Optional related issue URL'
+        required: false
+        type: string
+      related_pull_request_url:
+        description: 'Optional related pull request URL'
+        required: false
+        type: string
+      target_run_id:
+        description: 'Optional related workflow run id'
+        required: false
+        type: string
+      evidence_url:
+        description: 'Optional supporting evidence URL'
+        required: false
+        type: string
+      recorded_by:
+        description: 'Optional recorder identity override'
+        required: false
+        type: string
+      transcribed_for:
+        description: 'Optional human identity when transcribing feedback'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  human-go-no-go-feedback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: node tools/npm/cli.mjs ci --ignore-scripts
+
+      - name: Record human go/no-go decision
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        shell: bash
+        run: |
+          args=(
+            "tools/priority/human-go-no-go-feedback.mjs"
+            "--repo" "${{ github.repository }}"
+            "--target-context" "${{ inputs.target_context }}"
+            "--target-ref" "${{ inputs.target_ref }}"
+            "--decision" "${{ inputs.decision }}"
+            "--feedback" "${{ inputs.feedback }}"
+            "--out" "tests/results/_agent/handoff/human-go-no-go-decision.json"
+            "--events-out" "tests/results/_agent/handoff/human-go-no-go-events.ndjson"
+            "--step-summary" "$GITHUB_STEP_SUMMARY"
+          )
+
+          if [[ -n "${{ inputs.related_issue_url }}" ]]; then
+            args+=("--issue-url" "${{ inputs.related_issue_url }}")
+          fi
+          if [[ -n "${{ inputs.related_pull_request_url }}" ]]; then
+            args+=("--pull-request-url" "${{ inputs.related_pull_request_url }}")
+          fi
+          if [[ -n "${{ inputs.target_run_id }}" ]]; then
+            args+=("--target-run-id" "${{ inputs.target_run_id }}")
+          fi
+          if [[ -n "${{ inputs.evidence_url }}" ]]; then
+            args+=("--evidence-url" "${{ inputs.evidence_url }}")
+          fi
+          if [[ -n "${{ inputs.recorded_by }}" ]]; then
+            args+=("--recorded-by" "${{ inputs.recorded_by }}")
+          fi
+          if [[ -n "${{ inputs.transcribed_for }}" ]]; then
+            args+=("--transcribed-for" "${{ inputs.transcribed_for }}")
+          fi
+
+          node "${args[@]}"
+
+      - name: Upload human go/no-go decision artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: human-go-no-go-decision
+          path: |
+            tests/results/_agent/handoff/human-go-no-go-decision.json
+            tests/results/_agent/handoff/human-go-no-go-events.ndjson
+          if-no-files-found: error

--- a/.github/workflows/issue-snapshot.yml
+++ b/.github/workflows/issue-snapshot.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: '20'
       - name: Sync standing-priority snapshot
         env:
+          AGENT_PRIORITY_UPSTREAM_REPOSITORY: LabVIEW-Community-CI-CD/compare-vi-cli-action
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -713,6 +713,7 @@ jobs:
           node-version: '20'
       - name: Sync standing-priority snapshot
         env:
+          AGENT_PRIORITY_UPSTREAM_REPOSITORY: LabVIEW-Community-CI-CD/compare-vi-cli-action
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -22,6 +22,204 @@ function createResponse(data, status = 200, statusText = 'OK') {
   };
 }
 
+const EXPECTED_DEVELOP_CHECKS = [
+  'lint',
+  'fixtures',
+  'session-index',
+  'issue-snapshot',
+  'semver',
+  'Policy Guard (Upstream) / policy-guard',
+  'hook-parity (windows-latest)',
+  'hook-parity (ubuntu-latest)',
+  'vi-history-scenarios-linux',
+  'agent-review-policy',
+  'commit-integrity'
+];
+
+const EXPECTED_MAIN_CHECKS = [
+  'lint',
+  'pester',
+  'vi-binary-check',
+  'vi-compare',
+  'Policy Guard (Upstream) / policy-guard',
+  'commit-integrity'
+];
+
+const EXPECTED_RELEASE_CHECKS = [
+  'lint',
+  'pester',
+  'publish',
+  'vi-binary-check',
+  'vi-compare',
+  'mock-cli',
+  'Policy Guard (Upstream) / policy-guard'
+];
+
+const EXPECTED_MERGE_QUEUE_PARAMS = {
+  merge_method: 'SQUASH',
+  grouping_strategy: 'ALLGREEN',
+  max_entries_to_build: 5,
+  min_entries_to_merge: 1,
+  max_entries_to_merge: 5,
+  min_entries_to_merge_wait_minutes: 1,
+  check_response_timeout_minutes: 60
+};
+
+function createAlignedRepoState(overrides = {}) {
+  return {
+    allow_squash_merge: true,
+    allow_merge_commit: false,
+    allow_rebase_merge: true,
+    allow_auto_merge: true,
+    delete_branch_on_merge: true,
+    ...overrides
+  };
+}
+
+function createAlignedBranchProtection(requiredChecks) {
+  return {
+    required_status_checks: {
+      strict: true,
+      contexts: [...requiredChecks],
+      checks: requiredChecks.map((context) => ({ context }))
+    },
+    enforce_admins: { enabled: false },
+    required_pull_request_reviews: null,
+    restrictions: null,
+    required_linear_history: { enabled: true },
+    allow_force_pushes: { enabled: false },
+    allow_deletions: { enabled: false },
+    block_creations: { enabled: false },
+    required_conversation_resolution: { enabled: false },
+    lock_branch: { enabled: false },
+    allow_fork_syncing: { enabled: false }
+  };
+}
+
+function createPullRequestRule({
+  dismissStaleReviewsOnPush = false,
+  requiredReviewThreadResolution = false,
+  allowedMergeMethods = ['squash', 'rebase']
+} = {}) {
+  return {
+    required_approving_review_count: 0,
+    dismiss_stale_reviews_on_push: dismissStaleReviewsOnPush,
+    require_code_owner_review: false,
+    require_last_push_approval: false,
+    required_review_thread_resolution: requiredReviewThreadResolution,
+    allowed_merge_methods: [...allowedMergeMethods]
+  };
+}
+
+function createRuleset({
+  id,
+  name,
+  includes,
+  requiredStatusChecks,
+  mergeQueue = null,
+  requiredLinearHistory = false,
+  pullRequestRule,
+  codeQuality = null,
+  copilotCodeReview = null
+}) {
+  const rules = [];
+  if (requiredLinearHistory) {
+    rules.push({ type: 'required_linear_history' });
+  }
+  if (mergeQueue) {
+    rules.push({ type: 'merge_queue', parameters: structuredClone(mergeQueue) });
+  }
+  if (requiredStatusChecks) {
+    rules.push({
+      type: 'required_status_checks',
+      parameters: {
+        strict_required_status_checks_policy: true,
+        do_not_enforce_on_create: false,
+        required_status_checks: requiredStatusChecks.map((context) => ({ context }))
+      }
+    });
+  }
+  if (pullRequestRule) {
+    rules.push({
+      type: 'pull_request',
+      parameters: structuredClone(pullRequestRule)
+    });
+  }
+  if (codeQuality) {
+    rules.push({
+      type: 'code_quality',
+      parameters: structuredClone(codeQuality)
+    });
+  }
+  if (copilotCodeReview) {
+    rules.push({
+      type: 'copilot_code_review',
+      parameters: structuredClone(copilotCodeReview)
+    });
+  }
+
+  return {
+    id,
+    name,
+    target: 'branch',
+    enforcement: 'active',
+    conditions: {
+      ref_name: {
+        include: [...includes],
+        exclude: []
+      }
+    },
+    bypass_actors: [],
+    rules
+  };
+}
+
+function createAlignedRulesets(ids = { develop: 8811898, main: 8614140, release: 8614172 }) {
+  return {
+    develop: createRuleset({
+      id: ids.develop,
+      name: 'develop',
+      includes: ['refs/heads/develop'],
+      requiredStatusChecks: EXPECTED_DEVELOP_CHECKS,
+      mergeQueue: EXPECTED_MERGE_QUEUE_PARAMS,
+      requiredLinearHistory: true,
+      pullRequestRule: createPullRequestRule(),
+      codeQuality: { severity: 'warnings' },
+      copilotCodeReview: {
+        review_on_push: true,
+        review_draft_pull_requests: false
+      }
+    }),
+    main: createRuleset({
+      id: ids.main,
+      name: 'main',
+      includes: ['refs/heads/main'],
+      requiredStatusChecks: EXPECTED_MAIN_CHECKS,
+      mergeQueue: EXPECTED_MERGE_QUEUE_PARAMS,
+      pullRequestRule: createPullRequestRule()
+    }),
+    release: createRuleset({
+      id: ids.release,
+      name: 'release',
+      includes: ['refs/heads/release/*'],
+      requiredStatusChecks: EXPECTED_RELEASE_CHECKS,
+      pullRequestRule: createPullRequestRule({
+        dismissStaleReviewsOnPush: true,
+        allowedMergeMethods: ['rebase']
+      })
+    })
+  };
+}
+
+function toRulesetSummary(ruleset) {
+  return {
+    id: ruleset.id,
+    name: ruleset.name,
+    target: ruleset.target,
+    enforcement: ruleset.enforcement
+  };
+}
+
 test('priority:policy --apply updates rulesets for develop/main/release', async () => {
   const expectedDevelopChecks = [
     'lint',
@@ -507,6 +705,413 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   assert.ok(
     logMessages.includes('Merge policy apply completed successfully.'),
     'apply success message expected'
+  );
+});
+
+test('priority:policy verifies fork-local rulesets by stable identity when manifest ids are missing', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const listUrl = `${repoUrl}/rulesets`;
+  const branchDevelopUrl = `${repoUrl}/branches/develop/protection`;
+  const branchMainUrl = `${repoUrl}/branches/main/protection`;
+  const expectedRulesetUrls = {
+    develop: `${repoUrl}/rulesets/8811898`,
+    main: `${repoUrl}/rulesets/8614140`,
+    release: `${repoUrl}/rulesets/8614172`
+  };
+  const rulesets = createAlignedRulesets({
+    develop: 99001,
+    main: 99002,
+    release: 99003
+  });
+
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    if (method !== 'GET') {
+      throw new Error(`Unexpected request ${method} ${url}`);
+    }
+    if (url === repoUrl) {
+      return createResponse(createAlignedRepoState());
+    }
+    if (url === branchDevelopUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_DEVELOP_CHECKS));
+    }
+    if (url === branchMainUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_MAIN_CHECKS));
+    }
+    if (url === expectedRulesetUrls.develop || url === expectedRulesetUrls.main || url === expectedRulesetUrls.release) {
+      return createResponse({ message: 'Not Found', status: '404' }, 404, 'Not Found');
+    }
+    if (url === listUrl) {
+      return createResponse([
+        toRulesetSummary(rulesets.develop),
+        toRulesetSummary(rulesets.main),
+        toRulesetSummary(rulesets.release)
+      ]);
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.develop.id}`) {
+      return createResponse(rulesets.develop);
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.main.id}`) {
+      return createResponse(rulesets.main);
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.release.id}`) {
+      return createResponse(rulesets.release);
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const logMessages = [];
+  const errorMessages = [];
+  const code = await run({
+    argv: ['node', 'check-policy.mjs'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: (msg) => logMessages.push(msg),
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 0, 'verify mode should pass with fork-local ruleset ids');
+  assert.deepEqual(errorMessages, []);
+  assert.ok(
+    logMessages.some((msg) => msg.includes('ruleset 8811898: resolved by stable identity to 99001')),
+    'develop ruleset should resolve by identity'
+  );
+  assert.ok(
+    logMessages.some((msg) => msg.includes('ruleset 8614140: resolved by stable identity to 99002')),
+    'main ruleset should resolve by identity'
+  );
+  assert.ok(
+    logMessages.some((msg) => msg.includes('ruleset 8614172: resolved by stable identity to 99003')),
+    'release ruleset should resolve by identity'
+  );
+});
+
+test('priority:policy --apply updates fork-local rulesets resolved by stable identity', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const listUrl = `${repoUrl}/rulesets`;
+  const branchDevelopUrl = `${repoUrl}/branches/develop/protection`;
+  const branchMainUrl = `${repoUrl}/branches/main/protection`;
+  const expectedRulesetUrls = {
+    develop: `${repoUrl}/rulesets/8811898`,
+    main: `${repoUrl}/rulesets/8614140`,
+    release: `${repoUrl}/rulesets/8614172`
+  };
+  const rulesets = createAlignedRulesets({
+    develop: 99101,
+    main: 99102,
+    release: 99103
+  });
+  rulesets.develop.conditions.ref_name.include = ['refs/heads/develop-drifted'];
+  rulesets.develop.rules = rulesets.develop.rules.filter(
+    (rule) => !['required_linear_history', 'merge_queue', 'code_quality', 'copilot_code_review'].includes(rule.type)
+  );
+  rulesets.develop.rules.find((rule) => rule.type === 'required_status_checks').parameters.required_status_checks =
+    EXPECTED_DEVELOP_CHECKS.filter((context) => context !== 'commit-integrity').map((context) => ({ context }));
+  rulesets.develop.rules.find((rule) => rule.type === 'pull_request').parameters.allowed_merge_methods = ['merge'];
+
+  rulesets.main.rules.find((rule) => rule.type === 'required_status_checks').parameters.required_status_checks =
+    EXPECTED_MAIN_CHECKS.filter((context) => context !== 'commit-integrity').map((context) => ({ context }));
+  rulesets.main.rules.find((rule) => rule.type === 'pull_request').parameters.allowed_merge_methods = ['merge'];
+
+  rulesets.release.rules.find((rule) => rule.type === 'required_status_checks').parameters.required_status_checks =
+    EXPECTED_RELEASE_CHECKS.filter((context) => context !== 'mock-cli').map((context) => ({ context }));
+  rulesets.release.rules.find((rule) => rule.type === 'pull_request').parameters.allowed_merge_methods = ['merge'];
+
+  const requests = [];
+  const updateRuleset = (current, payload) => ({
+    ...current,
+    name: payload.name,
+    target: payload.target,
+    enforcement: payload.enforcement,
+    conditions: structuredClone(payload.conditions),
+    bypass_actors: structuredClone(payload.bypass_actors),
+    rules: structuredClone(payload.rules)
+  });
+
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    requests.push({ method, url, body: options.body });
+    if (method === 'GET' && url === repoUrl) {
+      return createResponse(createAlignedRepoState());
+    }
+    if (method === 'GET' && url === branchDevelopUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_DEVELOP_CHECKS));
+    }
+    if (method === 'GET' && url === branchMainUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_MAIN_CHECKS));
+    }
+    if (method === 'GET' && (url === expectedRulesetUrls.develop || url === expectedRulesetUrls.main || url === expectedRulesetUrls.release)) {
+      return createResponse({ message: 'Not Found', status: '404' }, 404, 'Not Found');
+    }
+    if (method === 'GET' && url === listUrl) {
+      return createResponse([
+        toRulesetSummary(rulesets.develop),
+        toRulesetSummary(rulesets.main),
+        toRulesetSummary(rulesets.release)
+      ]);
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.develop.id}`) {
+      if (method === 'GET') {
+        return createResponse(rulesets.develop);
+      }
+      if (method === 'PUT') {
+        rulesets.develop = updateRuleset(rulesets.develop, JSON.parse(options.body));
+        return createResponse(rulesets.develop);
+      }
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.main.id}`) {
+      if (method === 'GET') {
+        return createResponse(rulesets.main);
+      }
+      if (method === 'PUT') {
+        rulesets.main = updateRuleset(rulesets.main, JSON.parse(options.body));
+        return createResponse(rulesets.main);
+      }
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.release.id}`) {
+      if (method === 'GET') {
+        return createResponse(rulesets.release);
+      }
+      if (method === 'PUT') {
+        rulesets.release = updateRuleset(rulesets.release, JSON.parse(options.body));
+        return createResponse(rulesets.release);
+      }
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs', '--apply'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: () => {},
+    error: () => {}
+  });
+
+  assert.equal(code, 0, 'apply mode should update fork-local rulesets resolved by identity');
+  assert.ok(
+    requests.some((entry) => entry.method === 'PUT' && entry.url === `${repoUrl}/rulesets/${rulesets.develop.id}`),
+    'develop ruleset should be updated using the fork-local id'
+  );
+  assert.ok(
+    !requests.some((entry) => entry.method === 'PUT' && entry.url === expectedRulesetUrls.develop),
+    'develop ruleset should not use the upstream manifest id once identity is resolved'
+  );
+  assert.deepEqual(
+    rulesets.develop.conditions.ref_name.include,
+    ['refs/heads/develop'],
+    'develop ruleset should repair include drift on the existing fork-local ruleset'
+  );
+  assert.ok(
+    rulesets.develop.rules.some((rule) => rule.type === 'required_linear_history'),
+    'develop ruleset should restore required_linear_history'
+  );
+  assert.ok(
+    rulesets.develop.rules.some((rule) => rule.type === 'merge_queue'),
+    'develop ruleset should restore merge_queue'
+  );
+  assert.ok(
+    rulesets.develop.rules.some((rule) => rule.type === 'code_quality'),
+    'develop ruleset should restore code_quality'
+  );
+  assert.ok(
+    rulesets.develop.rules.some((rule) => rule.type === 'copilot_code_review'),
+    'develop ruleset should restore copilot_code_review'
+  );
+  assert.deepEqual(
+    rulesets.main.rules
+      .find((rule) => rule.type === 'required_status_checks')
+      .parameters.required_status_checks.map((item) => item.context)
+      .sort(),
+    EXPECTED_MAIN_CHECKS.slice().sort(),
+    'main ruleset should restore required checks'
+  );
+  assert.deepEqual(
+    rulesets.release.rules
+      .find((rule) => rule.type === 'required_status_checks')
+      .parameters.required_status_checks.map((item) => item.context)
+      .sort(),
+    EXPECTED_RELEASE_CHECKS.slice().sort(),
+    'release ruleset should restore required checks'
+  );
+});
+
+test('priority:policy diagnostics use resolved fork-local ruleset ids after stable-identity resolution', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const listUrl = `${repoUrl}/rulesets`;
+  const branchDevelopUrl = `${repoUrl}/branches/develop/protection`;
+  const branchMainUrl = `${repoUrl}/branches/main/protection`;
+  const expectedRulesetUrls = {
+    develop: `${repoUrl}/rulesets/8811898`,
+    main: `${repoUrl}/rulesets/8614140`,
+    release: `${repoUrl}/rulesets/8614172`
+  };
+  const rulesets = createAlignedRulesets({
+    develop: 99301,
+    main: 99302,
+    release: 99303
+  });
+  rulesets.develop.rules.find((rule) => rule.type === 'required_status_checks').parameters.required_status_checks =
+    EXPECTED_DEVELOP_CHECKS.filter((context) => context !== 'commit-integrity').map((context) => ({ context }));
+
+  const errorMessages = [];
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    if (method !== 'GET') {
+      throw new Error(`Unexpected request ${method} ${url}`);
+    }
+    if (url === repoUrl) {
+      return createResponse(createAlignedRepoState());
+    }
+    if (url === branchDevelopUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_DEVELOP_CHECKS));
+    }
+    if (url === branchMainUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_MAIN_CHECKS));
+    }
+    if (url === expectedRulesetUrls.develop || url === expectedRulesetUrls.main || url === expectedRulesetUrls.release) {
+      return createResponse({ message: 'Not Found', status: '404' }, 404, 'Not Found');
+    }
+    if (url === listUrl) {
+      return createResponse([
+        toRulesetSummary(rulesets.develop),
+        toRulesetSummary(rulesets.main),
+        toRulesetSummary(rulesets.release)
+      ]);
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.develop.id}`) {
+      return createResponse(rulesets.develop);
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.main.id}`) {
+      return createResponse(rulesets.main);
+    }
+    if (url === `${repoUrl}/rulesets/${rulesets.release.id}`) {
+      return createResponse(rulesets.release);
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: () => {},
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 1, 'verify mode should fail when the resolved fork-local ruleset still drifts');
+  assert.ok(
+    errorMessages.some((msg) => msg.includes('ruleset 99301: required_status_checks: missing [commit-integrity]')),
+    'diff output should reference the resolved fork-local ruleset id'
+  );
+  assert.ok(
+    !errorMessages.some((msg) => msg.includes('ruleset 8811898: required_status_checks: missing [commit-integrity]')),
+    'diff output should not keep referring to the manifest id after identity resolution'
+  );
+});
+
+test('priority:policy --apply creates missing fork-local rulesets when no identity match exists', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const listUrl = `${repoUrl}/rulesets`;
+  const branchDevelopUrl = `${repoUrl}/branches/develop/protection`;
+  const branchMainUrl = `${repoUrl}/branches/main/protection`;
+  const createdRulesets = [];
+  let nextRulesetId = 99200;
+
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    if (method === 'GET' && url === repoUrl) {
+      return createResponse(createAlignedRepoState());
+    }
+    if (method === 'GET' && url === branchDevelopUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_DEVELOP_CHECKS));
+    }
+    if (method === 'GET' && url === branchMainUrl) {
+      return createResponse(createAlignedBranchProtection(EXPECTED_MAIN_CHECKS));
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8811898`) {
+      return createResponse({ message: 'Not Found', status: '404' }, 404, 'Not Found');
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8614140`) {
+      return createResponse({ message: 'Not Found', status: '404' }, 404, 'Not Found');
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8614172`) {
+      return createResponse({ message: 'Not Found', status: '404' }, 404, 'Not Found');
+    }
+    if (method === 'GET' && url === listUrl) {
+      return createResponse(createdRulesets.map((ruleset) => toRulesetSummary(ruleset)));
+    }
+    if (method === 'GET' && url.startsWith(`${repoUrl}/rulesets/`)) {
+      const id = Number(url.split('/').at(-1));
+      const match = createdRulesets.find((ruleset) => ruleset.id === id);
+      if (!match) {
+        return createResponse({ message: 'Not Found', status: '404' }, 404, 'Not Found');
+      }
+      return createResponse(match);
+    }
+    if (method === 'POST' && url === listUrl) {
+      const payload = JSON.parse(options.body);
+      const created = {
+        id: ++nextRulesetId,
+        ...payload
+      };
+      createdRulesets.push(created);
+      return createResponse(created);
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs', '--apply'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: () => {},
+    error: () => {}
+  });
+
+  assert.equal(code, 0, 'apply mode should create missing fork-local rulesets');
+  assert.equal(createdRulesets.length, 3, 'three fork-local rulesets should be created');
+  assert.deepEqual(
+    createdRulesets.map((ruleset) => ruleset.name).sort(),
+    ['develop', 'main', 'release'],
+    'created rulesets should cover develop/main/release identities'
+  );
+  const createdDevelopRuleset = createdRulesets.find((ruleset) => ruleset.name === 'develop');
+  assert.ok(
+    createdDevelopRuleset.rules.some((rule) => rule.type === 'merge_queue'),
+    'created develop ruleset should include merge_queue'
+  );
+  assert.ok(
+    createdDevelopRuleset.rules.some((rule) => rule.type === 'copilot_code_review'),
+    'created develop ruleset should include copilot_code_review'
   );
 });
 

--- a/tools/priority/__tests__/copilot-review-gate.test.mjs
+++ b/tools/priority/__tests__/copilot-review-gate.test.mjs
@@ -105,6 +105,47 @@ test('copilot-review-gate skips merge-group runs while keeping the required stat
   assert.deepEqual(result.report?.reasons, ['merge-group-skip']);
 });
 
+test('copilot-review-gate skips throughput fork repos before any live lookup', async () => {
+  const { runCopilotReviewGate } = await loadModule();
+  let reviewsCalled = false;
+  let threadsCalled = false;
+
+  const result = await runCopilotReviewGate({
+    argv: createArgv([
+      '--event-name',
+      'pull_request_target',
+      '--repo',
+      'svelderrainruiz/compare-vi-cli-action',
+      '--pr',
+      '304',
+      '--head-sha',
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '--base-ref',
+      'develop',
+      '--draft',
+      'false',
+    ]),
+    loadReviewsFn: async () => {
+      reviewsCalled = true;
+      return [];
+    },
+    loadThreadsFn: async () => {
+      threadsCalled = true;
+      return [];
+    },
+    writeReportFn: () => 'memory://copilot-review-gate-throughput-fork.json',
+    appendStepSummaryFn: () => {},
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report?.status, 'pass');
+  assert.equal(result.report?.gateState, 'skipped');
+  assert.deepEqual(result.report?.reasons, ['throughput-fork-skip']);
+  assert.equal(result.report?.signals.gateApplies, false);
+  assert.equal(reviewsCalled, false);
+  assert.equal(threadsCalled, false);
+});
+
 test('copilot-review-gate passes stale but clean follow-up heads after an earlier Copilot review', async () => {
   const { runCopilotReviewGate } = await loadModule();
   const currentHead = 'cccccccccccccccccccccccccccccccccccccccc';
@@ -351,6 +392,72 @@ test('copilot-review-gate can evaluate the current-head state from the collected
   assert.equal(result.exitCode, 0);
   assert.equal(result.report?.source.mode, 'signal');
   assert.equal(result.report?.gateState, 'ready');
+  assert.equal(reviewsCalled, false);
+  assert.equal(threadsCalled, false);
+});
+
+test('copilot-review-gate reads the signal artifact before throughput-fork preflight skipping', async (t) => {
+  const { runCopilotReviewGate } = await loadModule();
+  let reviewsCalled = false;
+  let threadsCalled = false;
+  const signalPath = createSignalFixture(t, 'copilot-review-signal-signal-only.json');
+
+  const result = await runCopilotReviewGate({
+    argv: createArgv([
+      '--event-name',
+      'pull_request_target',
+      '--pr',
+      '885',
+      '--head-sha',
+      '9999999999999999999999999999999999999999',
+      '--base-ref',
+      'develop',
+      '--draft',
+      'false',
+      '--signal',
+      signalPath,
+    ]),
+    readSignalFn: () => ({
+      schema: 'priority/copilot-review-signal@v1',
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      pullRequest: {
+        number: 885,
+        url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/885',
+        draft: false,
+        headSha: '9999999999999999999999999999999999999999',
+        baseRef: 'develop',
+      },
+      latestCopilotReview: {
+        id: '15',
+        state: 'COMMENTED',
+        commitId: '9999999999999999999999999999999999999999',
+        submittedAt: '2026-03-08T06:05:00Z',
+        url: 'https://github.com/example/review/15',
+        isCurrentHead: true,
+        bodySummary: 'Current-head Copilot review.',
+      },
+      staleReviews: [],
+      unresolvedThreads: [],
+      actionableComments: [],
+      errors: [],
+    }),
+    loadReviewsFn: async () => {
+      reviewsCalled = true;
+      return [];
+    },
+    loadThreadsFn: async () => {
+      threadsCalled = true;
+      return [];
+    },
+    writeReportFn: () => 'memory://copilot-review-gate-signal-only.json',
+    appendStepSummaryFn: () => {},
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report?.source.mode, 'signal');
+  assert.equal(result.report?.status, 'pass');
+  assert.equal(result.report?.gateState, 'ready');
+  assert.deepEqual(result.report?.reasons, ['current-head-review-clean']);
   assert.equal(reviewsCalled, false);
   assert.equal(threadsCalled, false);
 });

--- a/tools/priority/__tests__/human-go-no-go-feedback-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/human-go-no-go-feedback-workflow-contract.test.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('human go/no-go feedback workflow is workflow_dispatch-only and exposes the decision inputs', () => {
+  const workflow = readRepoFile('.github/workflows/human-go-no-go-feedback.yml');
+
+  assert.match(workflow, /^on:\s*\r?\n\s+workflow_dispatch:/m);
+  assert.doesNotMatch(workflow, /^\s*pull_request:/m);
+  assert.doesNotMatch(workflow, /^\s*pull_request_target:/m);
+  assert.match(workflow, /target_context:/);
+  assert.match(workflow, /target_ref:/);
+  assert.match(workflow, /decision:\s+\s*description: 'Human disposition for the next iteration'/ms);
+  assert.match(workflow, /options:\s+\s+- go\s+\s+- nogo/ms);
+  assert.match(workflow, /feedback:/);
+  assert.match(workflow, /transcribed_for:/);
+});
+
+test('human go/no-go feedback workflow records the checked-in decision artifact and uploads it deterministically', () => {
+  const workflow = readRepoFile('.github/workflows/human-go-no-go-feedback.yml');
+
+  assert.match(workflow, /tools\/priority\/human-go-no-go-feedback\.mjs/);
+  assert.match(workflow, /--out" "tests\/results\/_agent\/handoff\/human-go-no-go-decision\.json"/);
+  assert.match(workflow, /--events-out" "tests\/results\/_agent\/handoff\/human-go-no-go-events\.ndjson"/);
+  assert.match(workflow, /name: Upload human go\/no-go decision artifacts\s+if: always\(\)\s+uses: actions\/upload-artifact@v5/ms);
+  assert.match(workflow, /name: human-go-no-go-decision/);
+});
+
+test('human go/no-go feedback workflow keeps permissions read-only', () => {
+  const workflow = readRepoFile('.github/workflows/human-go-no-go-feedback.yml');
+
+  assert.match(workflow, /permissions:\s+contents: read/ms);
+  assert.doesNotMatch(workflow, /permissions:\s+write-all/);
+  assert.doesNotMatch(workflow, /deployments: write/);
+});

--- a/tools/priority/__tests__/human-go-no-go-feedback.test.mjs
+++ b/tools/priority/__tests__/human-go-no-go-feedback.test.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import {
+  DEFAULT_ARTIFACT_NAME,
+  buildHumanGoNoGoPayload,
+  parseArgs,
+  runHumanGoNoGoFeedback,
+} from '../human-go-no-go-feedback.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('parseArgs accepts required and optional inputs', () => {
+  const parsed = parseArgs([
+    'node',
+    'human-go-no-go-feedback.mjs',
+    '--repo',
+    'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    '--target-context',
+    'issue/origin-982-human-go-no-go-workflow',
+    '--target-ref',
+    'issue/origin-982-human-go-no-go-workflow',
+    '--decision',
+    'nogo',
+    '--feedback',
+    'Needs another pass.',
+    '--issue-url',
+    'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/982',
+    '--pull-request-url',
+    'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/999',
+    '--target-run-id',
+    '22890012345',
+    '--evidence-url',
+    'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22890012345',
+    '--recorded-by',
+    'svelderrainruiz',
+    '--transcribed-for',
+    'human-operator',
+    '--next-action',
+    'pause',
+    '--next-seed',
+    'Wait for review.',
+  ]);
+
+  assert.equal(parsed.repo, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(parsed.decision, 'nogo');
+  assert.equal(parsed.transcribedFor, 'human-operator');
+  assert.equal(parsed.nextAction, 'pause');
+});
+
+test('buildHumanGoNoGoPayload derives run URL and next action from environment', () => {
+  const payload = buildHumanGoNoGoPayload(
+    {
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      targetContext: 'issue/origin-982-human-go-no-go-workflow',
+      targetRef: 'issue/origin-982-human-go-no-go-workflow',
+      decision: 'go',
+      feedback: 'Proceed to implementation.',
+      issueUrl: null,
+      pullRequestUrl: null,
+      targetRunId: null,
+      runUrl: null,
+      evidenceUrl: null,
+      recordedBy: null,
+      transcribedFor: null,
+      nextAction: null,
+      nextSeed: null,
+    },
+    {
+      GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_RUN_ID: '22890012345',
+      GITHUB_ACTOR: 'svelderrainruiz',
+    },
+    new Date('2026-03-10T02:40:00Z'),
+  );
+
+  assert.equal(payload.links.runUrl, 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22890012345');
+  assert.equal(payload.decision.recordedBy, 'svelderrainruiz');
+  assert.equal(payload.nextIteration.recommendedAction, 'continue');
+  assert.equal(payload.artifacts.artifactName, DEFAULT_ARTIFACT_NAME);
+});
+
+test('runHumanGoNoGoFeedback writes schema-valid decision and event artifacts', async (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'human-go-no-go-'));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const outPath = path.join(tmpDir, 'human-go-no-go-decision.json');
+  const eventsPath = path.join(tmpDir, 'human-go-no-go-events.ndjson');
+  const summaryPath = path.join(tmpDir, 'step-summary.md');
+
+  const result = await runHumanGoNoGoFeedback({
+    argv: [
+      'node',
+      'human-go-no-go-feedback.mjs',
+      '--repo',
+      'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      '--target-context',
+      'issue/origin-982-human-go-no-go-workflow',
+      '--target-ref',
+      'issue/origin-982-human-go-no-go-workflow',
+      '--decision',
+      'nogo',
+      '--feedback',
+      'Tighten workflow permissions before promotion.',
+      '--issue-url',
+      'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/982',
+      '--out',
+      outPath,
+      '--events-out',
+      eventsPath,
+      '--step-summary',
+      summaryPath,
+    ],
+    environment: {
+      GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      GITHUB_SERVER_URL: 'https://github.com',
+      GITHUB_RUN_ID: '22890012345',
+      GITHUB_ACTOR: 'svelderrainruiz',
+    },
+    now: new Date('2026-03-10T02:45:00Z'),
+  });
+
+  assert.equal(result.exitCode, 0);
+
+  const payload = JSON.parse(await readFile(outPath, 'utf8'));
+  const events = (await readFile(eventsPath, 'utf8')).trim().split(/\r?\n/).map((line) => JSON.parse(line));
+  const summary = await readFile(summaryPath, 'utf8');
+
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'human-go-no-go-decision-v1.schema.json');
+  if (fs.existsSync(schemaPath)) {
+    const materializedSchema = JSON.parse(await readFile(schemaPath, 'utf8'));
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(materializedSchema);
+    assert.equal(validate(payload), true, JSON.stringify(validate.errors, null, 2));
+  } else {
+    assert.equal(payload.schema, 'human-go-no-go-decision@v1');
+  }
+  assert.equal(payload.decision.value, 'nogo');
+  assert.equal(payload.nextIteration.recommendedAction, 'revise');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].decision, 'nogo');
+  assert.match(summary, /Human Go\/No-Go Feedback/);
+});

--- a/tools/priority/__tests__/standing-priority-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/standing-priority-workflow-contract.test.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+const canonicalUpstreamSlug = 'LabVIEW-Community-CI-CD/compare-vi-cli-action';
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+test('issue-event standing-priority snapshot resolves fork context through the canonical upstream slug', () => {
+  const workflow = readRepoFile('.github/workflows/issue-snapshot.yml');
+  const stepPattern = new RegExp(
+    [
+      '- name: Sync standing-priority snapshot',
+      '[\\s\\S]*?',
+      `AGENT_PRIORITY_UPSTREAM_REPOSITORY: ${escapeRegExp(canonicalUpstreamSlug)}`,
+      '[\\s\\S]*?',
+      'node tools/npm/run-script\\.mjs priority:sync:lane'
+    ].join('')
+  );
+
+  assert.match(workflow, stepPattern);
+});
+
+test('validate standing-priority snapshot resolves fork context through the canonical upstream slug', () => {
+  const workflow = readRepoFile('.github/workflows/validate.yml');
+  const stepPattern = new RegExp(
+    [
+      '- name: Sync standing-priority snapshot',
+      '[\\s\\S]*?',
+      `AGENT_PRIORITY_UPSTREAM_REPOSITORY: ${escapeRegExp(canonicalUpstreamSlug)}`,
+      '[\\s\\S]*?',
+      'node tools/npm/run-script\\.mjs priority:sync:lane'
+    ].join('')
+  );
+
+  assert.match(workflow, stepPattern);
+});

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -283,6 +283,114 @@ async function fetchJson(url, token, fetchFn) {
   return requestJson(url, token, { fetchFn });
 }
 
+function normalizeRulesetListResponse(response) {
+  if (Array.isArray(response)) {
+    return response;
+  }
+  if (Array.isArray(response?.rulesets)) {
+    return response.rulesets;
+  }
+  if (Array.isArray(response?.items)) {
+    return response.items;
+  }
+  return [];
+}
+
+function normalizeRulesetIncludes(values = []) {
+  return [...new Set(
+    (Array.isArray(values) ? values : [])
+      .map((value) => (typeof value === 'string' ? value.trim() : ''))
+      .filter(Boolean)
+  )].sort();
+}
+
+function rulesetIncludesMatch(expectations, actual) {
+  if (!Array.isArray(expectations?.includes)) {
+    return true;
+  }
+
+  const expectedIncludes = normalizeRulesetIncludes(expectations.includes);
+  const actualIncludes = normalizeRulesetIncludes(actual?.conditions?.ref_name?.include ?? []);
+  return JSON.stringify(expectedIncludes) === JSON.stringify(actualIncludes);
+}
+
+function rulesetIdentityMatches(expectations, actual) {
+  if (!actual || typeof actual !== 'object') {
+    return false;
+  }
+
+  if (expectations?.name && actual.name !== expectations.name) {
+    return false;
+  }
+
+  if (expectations?.target && actual.target !== expectations.target) {
+    return false;
+  }
+
+  return rulesetIncludesMatch(expectations, actual);
+}
+
+function rulesetSummaryMatches(expectations, actual) {
+  if (!actual || typeof actual !== 'object') {
+    return false;
+  }
+
+  if (expectations?.name && actual.name !== expectations.name) {
+    return false;
+  }
+
+  if (expectations?.target && actual.target !== expectations.target) {
+    return false;
+  }
+
+  return true;
+}
+
+function selectRulesetIdentityCandidate(expectations, candidates = []) {
+  const matchingCandidates = (Array.isArray(candidates) ? candidates : []).filter((candidate) =>
+    rulesetSummaryMatches(expectations, candidate)
+  );
+  if (matchingCandidates.length === 0) {
+    return { match: null, resolution: 'missing', error: null };
+  }
+
+  const exactMatches = matchingCandidates.filter((candidate) => rulesetIdentityMatches(expectations, candidate));
+  if (exactMatches.length === 1) {
+    return { match: exactMatches[0], resolution: 'exact', error: null };
+  }
+  if (exactMatches.length > 1) {
+    return {
+      match: null,
+      resolution: 'ambiguous',
+      error: new Error(
+        `multiple rulesets matched stable identity exactly (${exactMatches
+          .map((candidate) => candidate?.id ?? 'unknown')
+          .join(', ')})`
+      )
+    };
+  }
+
+  if (matchingCandidates.length === 1) {
+    return { match: matchingCandidates[0], resolution: 'summary', error: null };
+  }
+
+  const includeSummary = Array.isArray(expectations?.includes)
+    ? normalizeRulesetIncludes(expectations.includes).join(', ') || '(empty)'
+    : '(unspecified)';
+  return {
+    match: null,
+    resolution: 'ambiguous',
+    error: new Error(
+      `multiple rulesets matched stable identity by name/target and includes ${includeSummary} did not disambiguate`
+    )
+  };
+}
+
+async function listRulesets(repoUrl, token, fetchFn) {
+  const response = await fetchJson(`${repoUrl}/rulesets`, token, fetchFn);
+  return normalizeRulesetListResponse(response);
+}
+
 function compareRepoSettings(expected, actual) {
   const diffs = [];
   for (const [key, value] of Object.entries(expected)) {
@@ -583,6 +691,12 @@ function compareRulesetIncludes(expected = [], actual = []) {
   return diffs;
 }
 
+function prefixRulesetDiffs(id, diffs = []) {
+  return (Array.isArray(diffs) ? diffs : []).map((diff) =>
+    typeof diff === 'string' && diff.startsWith('ruleset ') ? diff : `ruleset ${id}: ${diff}`
+  );
+}
+
 function compareRuleset(id, expected, actual) {
   if (!actual) {
     return [`ruleset ${id}: not found`];
@@ -823,18 +937,14 @@ function updateOptionalParameterizedRule(rules, type, expected, actualRule) {
     : (actualRule?.parameters ?? rule.parameters ?? {});
 }
 
-function buildUpdatedRuleset(expectations, actual) {
-  if (!actual) {
-    throw new Error('Cannot apply ruleset changes: ruleset not found.');
-  }
-
+function buildRulesetPayload(expectations, actual = null) {
   const updated = {
-    name: actual.name,
-    target: actual.target,
-    enforcement: actual.enforcement,
-    conditions: structuredClone(actual.conditions ?? {}),
-    bypass_actors: sanitizeBypassActors(actual.bypass_actors),
-    rules: structuredClone(actual.rules ?? [])
+    name: actual?.name ?? expectations.name ?? 'ruleset',
+    target: actual?.target ?? expectations.target ?? 'branch',
+    enforcement: actual?.enforcement ?? 'active',
+    conditions: structuredClone(actual?.conditions ?? {}),
+    bypass_actors: sanitizeBypassActors(actual?.bypass_actors),
+    rules: structuredClone(actual?.rules ?? [])
   };
 
   if (Array.isArray(expectations.includes)) {
@@ -899,12 +1009,21 @@ async function applyBranchProtection(repoUrl, token, branch, expected, actual, f
 
 async function applyRuleset(repoUrl, token, id, expectations, actual, fetchFn, logFn = console.log) {
   const rulesetUrl = `${repoUrl}/rulesets/${id}`;
-  const payload = buildUpdatedRuleset(expectations, actual);
+  const payload = buildRulesetPayload(expectations, actual);
   await requestJson(rulesetUrl, token, { method: 'PUT', body: payload, fetchFn });
   logFn(`[policy] ruleset ${id}: applied configuration.`);
 }
 
-async function collectState(manifest, repoUrl, token, fetchFn) {
+async function createRuleset(repoUrl, token, expectations, fetchFn, logFn = console.log) {
+  const rulesetUrl = `${repoUrl}/rulesets`;
+  const payload = buildRulesetPayload(expectations);
+  const created = await requestJson(rulesetUrl, token, { method: 'POST', body: payload, fetchFn });
+  const suffix = created?.id ? ` as ${created.id}` : '';
+  logFn(`[policy] ruleset ${expectations?.name ?? 'unknown'}: created${suffix}.`);
+  return created;
+}
+
+async function collectState(manifest, repoUrl, token, fetchFn, logFn = console.log) {
   const repoData = await fetchJson(repoUrl, token, fetchFn);
 
   const branchStates = [];
@@ -925,9 +1044,23 @@ async function collectState(manifest, repoUrl, token, fetchFn) {
   }
 
   const rulesetStates = [];
+  let rulesetListPromise = null;
+  const loadRulesets = async () => {
+    if (!rulesetListPromise) {
+      rulesetListPromise = listRulesets(repoUrl, token, fetchFn);
+    }
+    return rulesetListPromise;
+  };
   for (const [rulesetId, expectations] of Object.entries(manifest.rulesets ?? {})) {
     const numericId = Number(rulesetId);
-    const state = { id: numericId, expectations, ruleset: null, error: null };
+    const state = {
+      id: numericId,
+      expectations,
+      ruleset: null,
+      error: null,
+      resolvedId: Number.isNaN(numericId) ? null : numericId,
+      resolvedBy: 'id'
+    };
     if (Number.isNaN(numericId)) {
       state.error = new Error('invalid id');
       rulesetStates.push(state);
@@ -937,7 +1070,43 @@ async function collectState(manifest, repoUrl, token, fetchFn) {
       const rulesetUrl = `${repoUrl}/rulesets/${numericId}`;
       state.ruleset = await fetchJson(rulesetUrl, token, fetchFn);
     } catch (error) {
-      state.error = error;
+      if (isNotFoundError(error)) {
+        try {
+          const rulesets = await loadRulesets();
+          const detailedMatches = [];
+          for (const candidate of rulesets) {
+            if (!rulesetSummaryMatches(expectations, candidate)) {
+              continue;
+            }
+            const detailedRuleset = candidate.id
+              ? await fetchJson(`${repoUrl}/rulesets/${candidate.id}`, token, fetchFn)
+              : candidate;
+            detailedMatches.push(detailedRuleset);
+          }
+          const selection = selectRulesetIdentityCandidate(expectations, detailedMatches);
+          const matchedRuleset = selection.match;
+          if (matchedRuleset) {
+            state.resolvedId = matchedRuleset.id ?? numericId;
+            state.resolvedBy = 'identity';
+            if (matchedRuleset.id && matchedRuleset.id !== numericId) {
+              const driftNote =
+                selection.resolution === 'summary'
+                  ? ' via name/target; include drift will be corrected during apply.'
+                  : '.';
+              logFn(`[policy] ruleset ${numericId}: resolved by stable identity to ${matchedRuleset.id}${driftNote}`);
+            }
+            state.ruleset = matchedRuleset;
+          } else if (selection.error) {
+            state.error = selection.error;
+          } else {
+            state.error = error;
+          }
+        } catch (lookupError) {
+          state.error = lookupError;
+        }
+      } else {
+        state.error = error;
+      }
     }
     rulesetStates.push(state);
   }
@@ -973,7 +1142,12 @@ function evaluateDiffs(manifest, state) {
       );
       continue;
     }
-    rulesetDiffs.push(...compareRuleset(entry.id, entry.expectations, entry.ruleset));
+    rulesetDiffs.push(
+      ...prefixRulesetDiffs(
+        entry.resolvedId ?? entry.id,
+        compareRuleset(entry.resolvedId ?? entry.id, entry.expectations, entry.ruleset)
+      )
+    );
   }
 
   return { repoDiffs, branchDiffs, rulesetDiffs };
@@ -1126,7 +1300,7 @@ export async function run({
     let initialState;
     try {
       initialState = await invokeWithAuthFallback('collectState', (token) =>
-        collectState(manifest, repoUrl, token, fetchFn)
+        collectState(manifest, repoUrl, token, fetchFn, log)
       );
     } catch (authError) {
       if (!options.apply && authError?.code === 'POLICY_AUTH_UNAVAILABLE') {
@@ -1154,7 +1328,10 @@ export async function run({
           dbg(`Ruleset ${entry.id} fetch error: ${entry.error.message}`);
         } else {
           const rule = entry.ruleset ?? {};
-          dbg(`Ruleset ${entry.id} keys: ${Object.keys(rule).join(', ') || '(none)'}`);
+          dbg(
+            `Ruleset ${entry.id} keys: ${Object.keys(rule).join(', ') || '(none)'} ` +
+            `(resolvedId=${entry.resolvedId ?? 'n/a'}, via=${entry.resolvedBy})`
+          );
         }
       }
     }
@@ -1215,29 +1392,38 @@ export async function run({
 
       const rulesetStatesNeedingUpdates = initialState.rulesetStates.filter((entry) => {
         if (entry.error) {
-          return false;
+          return isNotFoundError(entry.error);
         }
-        const diffs = compareRuleset(entry.id, entry.expectations, entry.ruleset);
+        const diffs = compareRuleset(entry.resolvedId ?? entry.id, entry.expectations, entry.ruleset);
         return diffs.length > 0;
       });
 
       for (const entry of rulesetStatesNeedingUpdates) {
-        await invokeWithAuthFallback(`applyRuleset(${entry.id})`, (token) =>
+        if (entry.error && isNotFoundError(entry.error)) {
+          const created = await invokeWithAuthFallback(`createRuleset(${entry.id})`, (token) =>
+            createRuleset(repoUrl, token, entry.expectations, fetchFn, log)
+          );
+          report.applied.rulesets.push(created?.id ?? entry.id);
+          continue;
+        }
+
+        const appliedRulesetId = entry.resolvedId ?? entry.id;
+        await invokeWithAuthFallback(`applyRuleset(${appliedRulesetId})`, (token) =>
           applyRuleset(
             repoUrl,
             token,
-            entry.id,
+            appliedRulesetId,
             entry.expectations,
             entry.ruleset,
             fetchFn,
             log
           )
         );
-        report.applied.rulesets.push(entry.id);
+        report.applied.rulesets.push(appliedRulesetId);
       }
 
       const postState = await invokeWithAuthFallback('collectState(post-apply)', (token) =>
-        collectState(manifest, repoUrl, token, fetchFn)
+        collectState(manifest, repoUrl, token, fetchFn, log)
       );
       const postDiffs = evaluateDiffs(manifest, postState);
       applyDiffsToReport(postDiffs);
@@ -1287,9 +1473,16 @@ export const __test = Object.freeze({
   compareBranchBooleanSetting,
   compareBranchNullableSetting,
   buildBranchProtectionPayload,
+  buildRulesetPayload,
   resolveEnabledFlag,
   compareOptionalParameterizedRule,
-  normalizeOptionalRuleExpectation
+  normalizeOptionalRuleExpectation,
+  normalizeRulesetListResponse,
+  normalizeRulesetIncludes,
+  prefixRulesetDiffs,
+  rulesetIncludesMatch,
+  rulesetIdentityMatches,
+  selectRulesetIdentityCandidate
 });
 
 const modulePath = path.resolve(fileURLToPath(import.meta.url));

--- a/tools/priority/copilot-review-gate.mjs
+++ b/tools/priority/copilot-review-gate.mjs
@@ -17,6 +17,7 @@ const DEFAULT_GATED_BASE_REFS = ['develop'];
 const DEFAULT_POLL_ATTEMPTS = 1;
 const DEFAULT_POLL_DELAY_MS = 10000;
 const GITHUB_API_URL = 'https://api.github.com';
+const CANONICAL_REPOSITORY = 'LabVIEW-Community-CI-CD/compare-vi-cli-action';
 
 const COPILOT_LOGINS = new Set([
   'copilot',
@@ -193,6 +194,11 @@ export function parseRepoSlug(repo) {
 
   const [owner, repoName] = segments;
   return { owner, repo: repoName };
+}
+
+function isCanonicalRepository(repo) {
+  const normalized = normalizeText(repo)?.toLowerCase();
+  return normalized === CANONICAL_REPOSITORY.toLowerCase();
 }
 
 function isCopilotLogin(login) {
@@ -559,10 +565,11 @@ function evaluateGateOutcome({
 }) {
   const reasons = [];
   const normalizedBaseRef = normalizeBaseRef(pullRequest.baseRef)?.toLowerCase() ?? null;
+  const canonicalRepository = isCanonicalRepository(repository);
   const gateApplies =
     eventName !== 'merge_group' &&
     pullRequest.draft !== true &&
-    Boolean(normalizedBaseRef && gatedBaseRefs.includes(normalizedBaseRef));
+    Boolean(normalizedBaseRef && gatedBaseRefs.includes(normalizedBaseRef) && canonicalRepository);
 
   const summary = {
     copilotReviewCount: reviews.length,
@@ -620,6 +627,9 @@ function evaluateGateOutcome({
   } else if (!normalizedBaseRef || !gatedBaseRefs.includes(normalizedBaseRef)) {
     gateState = 'skipped';
     reasons.push('base-ref-not-gated');
+  } else if (!canonicalRepository) {
+    gateState = 'skipped';
+    reasons.push('throughput-fork-skip');
   } else if (errors.length > 0) {
     status = 'fail';
     gateState = 'error';
@@ -953,18 +963,24 @@ export async function runCopilotReviewGate({
   let report;
 
   try {
-    const preflightPullRequest = buildPullRequest(options);
+    const signalPathExists = options.signalPath && existsSync(path.resolve(process.cwd(), options.signalPath));
+    const signalReport = signalPathExists ? readSignalFn(options.signalPath) : null;
+    const preflightPullRequest = buildPullRequest(options, signalReport);
     const preflightBaseRef = normalizeBaseRef(preflightPullRequest.baseRef)?.toLowerCase() ?? null;
+    const preflightRepository =
+      normalizeText(signalReport?.repository) ??
+      normalizeText(options.repo);
     const shouldSkipWithoutLookup =
       options.eventName === 'merge_group' ||
       preflightPullRequest.draft === true ||
       !preflightBaseRef ||
-      !options.gatedBaseRefs.includes(preflightBaseRef);
+      !options.gatedBaseRefs.includes(preflightBaseRef) ||
+      (preflightRepository !== null && !isCanonicalRepository(preflightRepository));
 
     if (shouldSkipWithoutLookup) {
       report = evaluateGateOutcome({
         eventName: options.eventName,
-        repository: normalizeText(options.repo),
+        repository: preflightRepository,
         sourceMode: options.eventName === 'merge_group' ? 'merge-group' : 'metadata',
         pullRequest: preflightPullRequest,
         reviews: [],
@@ -973,8 +989,7 @@ export async function runCopilotReviewGate({
         gatedBaseRefs: options.gatedBaseRefs,
         now,
       });
-    } else if (options.signalPath && existsSync(path.resolve(process.cwd(), options.signalPath))) {
-      const signalReport = readSignalFn(options.signalPath);
+    } else if (signalReport) {
       report = buildReportFromSignal(options, signalReport, now);
     } else {
       const reviews = await loadReviewsFn(options);

--- a/tools/priority/human-go-no-go-feedback.mjs
+++ b/tools/priority/human-go-no-go-feedback.mjs
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+export const HUMAN_GO_NO_GO_DECISION_SCHEMA = 'human-go-no-go-decision@v1';
+export const DEFAULT_WORKFLOW_NAME = 'Human Go/No-Go Feedback';
+export const DEFAULT_WORKFLOW_PATH = '.github/workflows/human-go-no-go-feedback.yml';
+export const DEFAULT_ARTIFACT_NAME = 'human-go-no-go-decision';
+export const DEFAULT_OUT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'handoff',
+  'human-go-no-go-decision.json',
+);
+export const DEFAULT_EVENTS_OUT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'handoff',
+  'human-go-no-go-events.ndjson',
+);
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DEFAULT_SCHEMA_PATH = path.join(
+  repoRoot,
+  'docs',
+  'schemas',
+  'human-go-no-go-decision-v1.schema.json',
+);
+
+function printUsage() {
+  const lines = [
+    'Usage: node tools/priority/human-go-no-go-feedback.mjs [options]',
+    '',
+    'Write a machine-readable human go/no-go decision artifact for later agent reuse.',
+    '',
+    'Options:',
+    '  --repo <owner/repo>            Repository slug (default: GITHUB_REPOSITORY).',
+    '  --target-context <id>          Required target context identifier.',
+    '  --target-ref <ref>             Required target ref or branch name.',
+    '  --decision <go|nogo>          Required human decision.',
+    '  --feedback <text>             Required free-form feedback text.',
+    '  --issue-url <url>             Optional related issue URL.',
+    '  --pull-request-url <url>      Optional related pull request URL.',
+    '  --target-run-id <id>          Optional related workflow run id.',
+    '  --run-url <url>               Optional workflow run URL (default: derive from GitHub env).',
+    '  --evidence-url <url>          Optional supporting evidence URL.',
+    '  --recorded-by <identity>      Optional recorder identity (default: GITHUB_ACTOR).',
+    '  --transcribed-for <identity>  Optional human identity when transcribing another operator.',
+    '  --next-action <value>         Optional next action override (continue|revise|pause).',
+    '  --next-seed <text>            Optional next-iteration seed override.',
+    `  --out <path>                  Decision JSON output path (default: ${DEFAULT_OUT_PATH}).`,
+    `  --events-out <path>           NDJSON events path (default: ${DEFAULT_EVENTS_OUT_PATH}).`,
+    '  --step-summary <path>         Optional GitHub step summary path.',
+    '  -h, --help                    Show this message and exit.',
+  ];
+
+  for (const line of lines) {
+    console.log(line);
+  }
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeRepositorySlug(value) {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return null;
+  }
+  const segments = normalized.split('/').map((segment) => segment.trim());
+  if (segments.length !== 2 || segments.some((segment) => !segment)) {
+    throw new Error(`Invalid repository slug '${value}'. Expected <owner>/<repo>.`);
+  }
+  return `${segments[0]}/${segments[1]}`;
+}
+
+function normalizeUrl(value, label) {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new Error(`Invalid ${label} URL '${value}'.`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Invalid ${label} URL '${value}'. Expected http:// or https://.`);
+  }
+
+  return parsed.toString();
+}
+
+function normalizeDecision(value) {
+  const normalized = normalizeText(value)?.toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized !== 'go' && normalized !== 'nogo') {
+    throw new Error(`Invalid decision '${value}'. Expected go or nogo.`);
+  }
+  return normalized;
+}
+
+function normalizeNextAction(value) {
+  const normalized = normalizeText(value)?.toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (!['continue', 'revise', 'pause'].includes(normalized)) {
+    throw new Error(`Invalid next action '${value}'. Expected continue, revise, or pause.`);
+  }
+  return normalized;
+}
+
+function deriveRunUrl(repository, environment = process.env) {
+  const serverUrl = normalizeText(environment.GITHUB_SERVER_URL);
+  const runId = normalizeText(environment.GITHUB_RUN_ID);
+  if (!serverUrl || !runId || !repository) {
+    return null;
+  }
+  return `${serverUrl.replace(/\/+$/, '')}/${repository}/actions/runs/${runId}`;
+}
+
+function deriveRecordedBy(explicit, environment = process.env) {
+  return normalizeText(explicit) ?? normalizeText(environment.GITHUB_ACTOR);
+}
+
+function defaultNextActionForDecision(decision) {
+  return decision === 'go' ? 'continue' : 'revise';
+}
+
+function readSchema(schemaPath = DEFAULT_SCHEMA_PATH) {
+  const resolved = path.resolve(schemaPath);
+  if (!existsSync(resolved)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(resolved, 'utf8'));
+}
+
+function validatePayloadAgainstSchema(payload, schema = readSchema()) {
+  // #982 can stack ahead of #981 on a fork lane, so runtime validation stays
+  // opportunistic until the checked-in contract schema is present on the branch.
+  if (!schema) {
+    return;
+  }
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(payload);
+  if (!valid) {
+    throw new Error(`Decision payload failed schema validation: ${JSON.stringify(validate.errors, null, 2)}`);
+  }
+}
+
+async function writeJsonFile(filePath, payload) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+async function writeEventsFile(filePath, entries) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  const content = entries.map((entry) => JSON.stringify(entry)).join('\n');
+  await writeFile(resolved, `${content}\n`, 'utf8');
+  return resolved;
+}
+
+async function appendStepSummary(stepSummaryPath, payload) {
+  if (!stepSummaryPath) {
+    return null;
+  }
+
+  const resolved = path.resolve(process.cwd(), stepSummaryPath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  const lines = [
+    '### Human Go/No-Go Feedback',
+    '',
+    `- repository: \`${payload.target.repository}\``,
+    `- target_context: \`${payload.target.context}\``,
+    `- target_ref: \`${payload.target.ref}\``,
+    `- decision: \`${payload.decision.value}\``,
+    `- recorded_by: \`${payload.decision.recordedBy ?? 'unknown'}\``,
+    `- transcribed_for: \`${payload.decision.transcribedFor ?? 'none'}\``,
+    `- issue_url: \`${payload.target.issueUrl ?? 'none'}\``,
+    `- pull_request_url: \`${payload.target.pullRequestUrl ?? 'none'}\``,
+    `- run_url: \`${payload.links.runUrl ?? 'none'}\``,
+    `- next_action: \`${payload.nextIteration.recommendedAction}\``,
+    '',
+    'Feedback:',
+    '',
+    payload.decision.feedback,
+  ];
+  await writeFile(resolved, `${lines.join('\n')}\n`, { encoding: 'utf8', flag: 'a' });
+  return resolved;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    help: false,
+    repo: null,
+    targetContext: null,
+    targetRef: null,
+    decision: null,
+    feedback: null,
+    issueUrl: null,
+    pullRequestUrl: null,
+    targetRunId: null,
+    runUrl: null,
+    evidenceUrl: null,
+    recordedBy: null,
+    transcribedFor: null,
+    nextAction: null,
+    nextSeed: null,
+    outPath: DEFAULT_OUT_PATH,
+    eventsOutPath: DEFAULT_EVENTS_OUT_PATH,
+    stepSummaryPath: null,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (
+      token === '--repo' ||
+      token === '--target-context' ||
+      token === '--target-ref' ||
+      token === '--decision' ||
+      token === '--feedback' ||
+      token === '--issue-url' ||
+      token === '--pull-request-url' ||
+      token === '--target-run-id' ||
+      token === '--run-url' ||
+      token === '--evidence-url' ||
+      token === '--recorded-by' ||
+      token === '--transcribed-for' ||
+      token === '--next-action' ||
+      token === '--next-seed' ||
+      token === '--out' ||
+      token === '--events-out' ||
+      token === '--step-summary'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--repo') options.repo = normalizeRepositorySlug(next);
+      if (token === '--target-context') options.targetContext = normalizeText(next);
+      if (token === '--target-ref') options.targetRef = normalizeText(next);
+      if (token === '--decision') options.decision = normalizeDecision(next);
+      if (token === '--feedback') options.feedback = normalizeText(next);
+      if (token === '--issue-url') options.issueUrl = normalizeUrl(next, 'issue');
+      if (token === '--pull-request-url') options.pullRequestUrl = normalizeUrl(next, 'pull request');
+      if (token === '--target-run-id') options.targetRunId = normalizeText(next);
+      if (token === '--run-url') options.runUrl = normalizeUrl(next, 'run');
+      if (token === '--evidence-url') options.evidenceUrl = normalizeUrl(next, 'evidence');
+      if (token === '--recorded-by') options.recordedBy = normalizeText(next);
+      if (token === '--transcribed-for') options.transcribedFor = normalizeText(next);
+      if (token === '--next-action') options.nextAction = normalizeNextAction(next);
+      if (token === '--next-seed') options.nextSeed = normalizeText(next);
+      if (token === '--out') options.outPath = next;
+      if (token === '--events-out') options.eventsOutPath = next;
+      if (token === '--step-summary') options.stepSummaryPath = next;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!options.help) {
+    if (!options.targetContext) {
+      throw new Error('Target context is required. Pass --target-context <id>.');
+    }
+    if (!options.targetRef) {
+      throw new Error('Target ref is required. Pass --target-ref <ref>.');
+    }
+    if (!options.decision) {
+      throw new Error('Decision is required. Pass --decision <go|nogo>.');
+    }
+    if (!options.feedback) {
+      throw new Error('Feedback is required. Pass --feedback <text>.');
+    }
+  }
+
+  return options;
+}
+
+export function buildHumanGoNoGoPayload(options, environment = process.env, now = new Date()) {
+  const outPath = options.outPath ?? DEFAULT_OUT_PATH;
+  const eventsOutPath = options.eventsOutPath ?? DEFAULT_EVENTS_OUT_PATH;
+  const repository = options.repo ?? normalizeRepositorySlug(environment.GITHUB_REPOSITORY);
+  if (!repository) {
+    throw new Error('Repository is required. Pass --repo <owner/repo> or set GITHUB_REPOSITORY.');
+  }
+
+  const decisionValue = normalizeDecision(options.decision);
+  const nextAction = options.nextAction ?? defaultNextActionForDecision(decisionValue);
+  const runUrl = options.runUrl ?? deriveRunUrl(repository, environment);
+  const runId = options.targetRunId ?? normalizeText(environment.GITHUB_RUN_ID);
+  const feedback = normalizeText(options.feedback);
+  if (!feedback) {
+    throw new Error('Feedback is required.');
+  }
+
+  return {
+    schema: HUMAN_GO_NO_GO_DECISION_SCHEMA,
+    schemaVersion: '1.0.0',
+    generatedAt: new Date(now).toISOString(),
+    workflow: {
+      name: DEFAULT_WORKFLOW_NAME,
+      path: DEFAULT_WORKFLOW_PATH,
+    },
+    target: {
+      repository,
+      context: options.targetContext,
+      ref: options.targetRef,
+      runId,
+      issueUrl: options.issueUrl ?? null,
+      pullRequestUrl: options.pullRequestUrl ?? null,
+    },
+    decision: {
+      value: decisionValue,
+      feedback,
+      recordedBy: deriveRecordedBy(options.recordedBy, environment),
+      transcribedFor: options.transcribedFor ?? null,
+    },
+    links: {
+      runUrl,
+      evidenceUrl: options.evidenceUrl ?? null,
+    },
+    artifacts: {
+      artifactName: DEFAULT_ARTIFACT_NAME,
+      decisionPath: outPath.replace(/\\/g, '/'),
+      eventsPath: eventsOutPath.replace(/\\/g, '/'),
+    },
+    nextIteration: {
+      recommendedAction: nextAction,
+      seed: options.nextSeed ?? feedback,
+    },
+  };
+}
+
+export async function runHumanGoNoGoFeedback({
+  argv = process.argv,
+  environment = process.env,
+  now = new Date(),
+  writeJsonFileFn = writeJsonFile,
+  writeEventsFileFn = writeEventsFile,
+  appendStepSummaryFn = appendStepSummary,
+} = {}) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return { exitCode: 0, payload: null, outPath: null, eventsOutPath: null };
+  }
+
+  const payload = buildHumanGoNoGoPayload(options, environment, now);
+  validatePayloadAgainstSchema(payload);
+
+  const event = {
+    schema: 'human-go-no-go-feedback/event@v1',
+    recordedAt: payload.generatedAt,
+    decision: payload.decision.value,
+    repository: payload.target.repository,
+    targetContext: payload.target.context,
+    targetRef: payload.target.ref,
+    runId: payload.target.runId,
+  };
+
+  const [outPath, eventsOutPath] = await Promise.all([
+    writeJsonFileFn(options.outPath, payload),
+    writeEventsFileFn(options.eventsOutPath, [event]),
+  ]);
+
+  await appendStepSummaryFn(options.stepSummaryPath, payload);
+
+  console.log(`[human-go-no-go-feedback] decision: ${outPath}`);
+  console.log(`[human-go-no-go-feedback] events: ${eventsOutPath}`);
+  console.log(
+    `[human-go-no-go-feedback] decision=${payload.decision.value} next=${payload.nextIteration.recommendedAction}`,
+  );
+
+  return {
+    exitCode: 0,
+    payload,
+    outPath,
+    eventsOutPath,
+  };
+}
+
+function isDirectExecution() {
+  const entryPoint = process.argv[1] ? path.resolve(process.argv[1]) : null;
+  return entryPoint === fileURLToPath(import.meta.url);
+}
+
+if (isDirectExecution()) {
+  runHumanGoNoGoFeedback().catch((error) => {
+    console.error(`[human-go-no-go-feedback] ${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #982
- Issue title: Human go/no-go feedback: implement the manual disposition workflow and persist machine-readable results
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/982
- Standing priority at PR creation: No
- Base branch: `develop`
- Head branch: `issue/origin-982-human-go-no-go-workflow`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
