### PR TITLE
#6 Detect protected fork develop sync before direct push

### DIFF
--- a/tools/priority/Sync-OriginUpstreamDevelop.ps1
+++ b/tools/priority/Sync-OriginUpstreamDevelop.ps1
@@ -225,6 +225,200 @@ function Get-SafeRemoteLocation {
   return ($Location -replace '^(https?://)([^/@]+@)', '$1')
 }
 
+function Resolve-RemoteRepositorySlug {
+  param(
+    [Parameter(Mandatory)][string]$Remote
+  )
+
+  foreach ($candidate in @(
+      (Get-GitOptionalValue -Arguments @('remote', 'get-url', '--push', $Remote)),
+      (Get-GitOptionalValue -Arguments @('remote', 'get-url', $Remote))
+    )) {
+    if ([string]::IsNullOrWhiteSpace($candidate)) {
+      continue
+    }
+
+    if ($candidate -match ':(?<repoPath>[^/]+/[^/]+?)(?:\.git)?$') {
+      return $Matches['repoPath']
+    }
+    if ($candidate -match 'github\.com/(?<repoPath>[^/]+/[^/]+?)(?:\.git)?$') {
+      return $Matches['repoPath']
+    }
+  }
+
+  return ''
+}
+
+function Get-ActiveBranchRules {
+  param(
+    [Parameter(Mandatory)][string]$Repository,
+    [Parameter(Mandatory)][string]$BranchName
+  )
+
+  $encodedBranchName = [System.Uri]::EscapeDataString($BranchName)
+  $result = & gh api ("repos/{0}/rules/branches/{1}" -f $Repository, $encodedBranchName) 2>&1
+  $exitCode = $LASTEXITCODE
+  $text = (($result | ForEach-Object { [string]$_ }) -join "`n").Trim()
+  if ($exitCode -ne 0) {
+    if ($text) {
+      Write-Warning ("[sync] Unable to query active rules for {0}:{1}; continuing with direct sync detection. {2}" -f $Repository, $BranchName, $text)
+    } else {
+      Write-Warning ("[sync] Unable to query active rules for {0}:{1}; continuing with direct sync detection." -f $Repository, $BranchName)
+    }
+    return @()
+  }
+
+  if ([string]::IsNullOrWhiteSpace($text)) {
+    return @()
+  }
+
+  try {
+    $parsed = $text | ConvertFrom-Json -AsHashtable
+  } catch {
+    Write-Warning ("[sync] Active-rules query for {0}:{1} returned invalid JSON; continuing with direct sync detection. {2}" -f $Repository, $BranchName, $_.Exception.Message)
+    return @()
+  }
+
+  if ($parsed -is [System.Collections.IEnumerable] -and -not ($parsed -is [string]) -and -not ($parsed -is [System.Collections.IDictionary])) {
+    return @($parsed)
+  }
+
+  return @($parsed)
+}
+
+function Get-ActiveBranchRuleTypes {
+  param([object[]]$Rules = @())
+
+  if (-not $Rules -or $Rules.Count -eq 0) {
+    return @()
+  }
+
+  return @(
+    $Rules |
+      ForEach-Object {
+        if ($_ -is [System.Collections.IDictionary]) {
+          [string]$_['type']
+        } else {
+          [string]$_.type
+        }
+      } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+}
+
+function Test-ActiveBranchRulesRequireProtectedSync {
+  param([string[]]$RuleTypes = @())
+
+  if (-not $RuleTypes -or $RuleTypes.Count -eq 0) {
+    return $false
+  }
+
+  return ($RuleTypes -contains 'pull_request' -or $RuleTypes -contains 'merge_queue')
+}
+
+function Get-ActiveBranchRulesetIds {
+  param([object[]]$Rules = @())
+
+  if (-not $Rules -or $Rules.Count -eq 0) {
+    return @()
+  }
+
+  return @(
+    $Rules |
+      ForEach-Object {
+        if ($_ -is [System.Collections.IDictionary]) {
+          $_['ruleset_id']
+        } else {
+          $_.ruleset_id
+        }
+      } |
+      Where-Object { $_ -ne $null -and -not [string]::IsNullOrWhiteSpace([string]$_) } |
+      ForEach-Object { [string]$_ } |
+      Select-Object -Unique
+  )
+}
+
+function Get-RulesetCurrentUserBypassMode {
+  param(
+    [Parameter(Mandatory)][string]$Repository,
+    [Parameter(Mandatory)][string]$RulesetId
+  )
+
+  $result = & gh api ("repos/{0}/rulesets/{1}" -f $Repository, $RulesetId) 2>&1
+  $exitCode = $LASTEXITCODE
+  $text = (($result | ForEach-Object { [string]$_ }) -join "`n").Trim()
+  if ($exitCode -ne 0) {
+    if ($text) {
+      Write-Warning ("[sync] Unable to query ruleset {0} for {1}; continuing with direct sync detection. {2}" -f $RulesetId, $Repository, $text)
+    } else {
+      Write-Warning ("[sync] Unable to query ruleset {0} for {1}; continuing with direct sync detection." -f $RulesetId, $Repository)
+    }
+    return 'unknown'
+  }
+
+  if ([string]::IsNullOrWhiteSpace($text)) {
+    return 'unknown'
+  }
+
+  try {
+    $parsed = $text | ConvertFrom-Json -AsHashtable
+  } catch {
+    Write-Warning ("[sync] Ruleset query for {0}/{1} returned invalid JSON; continuing with direct sync detection. {2}" -f $Repository, $RulesetId, $_.Exception.Message)
+    return 'unknown'
+  }
+
+  $mode = [string]($parsed['current_user_can_bypass'] ?? '')
+  if ([string]::IsNullOrWhiteSpace($mode)) {
+    return 'unknown'
+  }
+  return $mode
+}
+
+function Get-ActiveProtectedSyncProbe {
+  param(
+    [Parameter(Mandatory)][string]$Repository,
+    [Parameter(Mandatory)][string]$BranchName
+  )
+
+  $rules = @(Get-ActiveBranchRules -Repository $Repository -BranchName $BranchName)
+  $ruleTypes = @(Get-ActiveBranchRuleTypes -Rules $rules)
+  $requiresProtectedRules = Test-ActiveBranchRulesRequireProtectedSync -RuleTypes $ruleTypes
+  if (-not $requiresProtectedRules) {
+    return [ordered]@{
+      required = $false
+      ruleTypes = $ruleTypes
+      rulesetIds = @()
+      bypassModes = @()
+      bypassAllowsDirectPush = $false
+    }
+  }
+
+  $rulesetIds = @(Get-ActiveBranchRulesetIds -Rules $rules)
+  $resolvedBypassModes = @(
+    $rulesetIds |
+      ForEach-Object { Get-RulesetCurrentUserBypassMode -Repository $Repository -RulesetId $_ } |
+      ForEach-Object { $_.ToLowerInvariant() }
+  )
+  $hasCompleteBypassData = (
+    $rulesetIds.Count -gt 0 -and
+    $resolvedBypassModes.Count -eq $rulesetIds.Count -and
+    -not ($resolvedBypassModes | Where-Object { $_ -eq 'unknown' })
+  )
+  $bypassModes = @($resolvedBypassModes | Select-Object -Unique)
+  $bypassAllowsDirectPush = (
+    $hasCompleteBypassData -and
+    -not ($resolvedBypassModes | Where-Object { $_ -ne 'always' })
+  )
+
+  return [ordered]@{
+    required = ($hasCompleteBypassData -and -not $bypassAllowsDirectPush)
+    ruleTypes = $ruleTypes
+    rulesetIds = $rulesetIds
+    bypassModes = $bypassModes
+    bypassAllowsDirectPush = $bypassAllowsDirectPush
+  }
+}
+
 function Invoke-PushWithTransportFallback {
   param(
     [Parameter(Mandatory)][string]$Remote,
@@ -321,6 +515,61 @@ function Get-ProtectedSyncBranchName {
   return "sync/$sanitizedRemote-$sanitizedBranch"
 }
 
+function Invoke-ProtectedBranchSync {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$BaseRemote,
+    [Parameter(Mandatory)][string]$HeadRemote,
+    [Parameter(Mandatory)][string]$BranchName,
+    [Parameter(Mandatory)][string]$Reason,
+    [Parameter(Mandatory)][string]$LocalHead,
+    [string[]]$RuleTypes = @()
+  )
+
+  $syncBranch = Get-ProtectedSyncBranchName -Remote $HeadRemote -BranchName $BranchName
+  if ($RuleTypes.Count -gt 0) {
+    Write-Warning ("[sync] Active branch rules require protected sync for {0}/{1}; routing through protected sync helper (sync branch {2}; rules: {3})" -f $HeadRemote, $BranchName, $syncBranch, ($RuleTypes -join ', '))
+  } else {
+    Write-Warning ("[sync] Protected branch rejected direct push to {0}/{1}; routing through protected sync helper (sync branch {2})" -f $HeadRemote, $BranchName, $syncBranch)
+  }
+  $pushTransport = Invoke-PushWithTransportFallback -Remote $HeadRemote -BranchName $syncBranch -SourceRef 'HEAD' -TargetBranch $syncBranch
+  $protectedSyncReportPath = Join-Path $RepoRoot ("tests/results/_agent/issue/{0}-protected-develop-sync.json" -f $HeadRemote)
+  Invoke-Node -Arguments @(
+    'tools/priority/protected-develop-sync-pr.mjs',
+    '--target-remote',
+    $HeadRemote,
+    '--base-remote',
+    $BaseRemote,
+    '--branch',
+    $BranchName,
+    '--sync-branch',
+    $syncBranch,
+    '--reason',
+    $Reason,
+    '--local-head',
+    $LocalHead,
+    '--report-path',
+    $protectedSyncReportPath
+  )
+  if (-not (Test-Path -LiteralPath $protectedSyncReportPath -PathType Leaf)) {
+    throw ("Protected sync report not found: {0}" -f $protectedSyncReportPath)
+  }
+  $protectedSync = Get-Content -LiteralPath $protectedSyncReportPath -Raw | ConvertFrom-Json -AsHashtable
+  $syncMethod = [string]($protectedSync['syncMethod'] ?? 'protected-pr')
+  if ($syncMethod -eq 'fork-sync') {
+    Remove-RemoteBranchWithTransportFallback -Remote $HeadRemote -BranchName $syncBranch
+    $pushTransport = $null
+  }
+
+  return [ordered]@{
+    syncBranch = $syncBranch
+    syncMethod = $syncMethod
+    pushTransport = $pushTransport
+    protectedSyncReportPath = $protectedSyncReportPath
+    protectedSync = $protectedSync
+  }
+}
+
 $repoRoot = Get-GitValue -Arguments @('rev-parse', '--show-toplevel')
 if ([string]::IsNullOrWhiteSpace($repoRoot)) {
   throw 'Unable to resolve git repository root.'
@@ -395,50 +644,49 @@ try {
 
       # Sequential by design: pull must complete before push starts.
       Invoke-Git -Arguments @('pull', '--ff-only', $BaseRemote, $Branch) | Out-Null
-      try {
-        $attemptPushTransport = Invoke-PushWithTransportFallback -Remote $HeadRemote -BranchName $Branch
-      }
-      catch {
-        $message = $_.Exception.Message
-        if (-not (Test-GitHubProtectedBranchFailure -Message $message)) {
-          throw
-        }
-
-        $attemptSyncReason = Get-ProtectedBranchSyncReason -Message $message
-        $localHead = Get-GitValue -Arguments @('rev-parse', 'HEAD')
-        $syncBranch = Get-ProtectedSyncBranchName -Remote $HeadRemote -BranchName $Branch
-        Write-Warning ("[sync] Protected branch rejected direct push to {0}/{1}; routing through protected sync helper (sync branch {2})" -f $HeadRemote, $Branch, $syncBranch)
-        $attemptPushTransport = Invoke-PushWithTransportFallback -Remote $HeadRemote -BranchName $syncBranch -SourceRef 'HEAD' -TargetBranch $syncBranch
-        $attemptProtectedSyncReportPath = Join-Path $repoRoot ("tests/results/_agent/issue/{0}-protected-develop-sync.json" -f $HeadRemote)
-        Invoke-Node -Arguments @(
-          'tools/priority/protected-develop-sync-pr.mjs',
-          '--target-remote',
-          $HeadRemote,
-          '--base-remote',
-          $BaseRemote,
-          '--branch',
-          $Branch,
-          '--sync-branch',
-          $syncBranch,
-          '--reason',
-          $attemptSyncReason,
-          '--local-head',
-          $localHead,
-          '--report-path',
-          $attemptProtectedSyncReportPath
-        )
-        if (-not (Test-Path -LiteralPath $attemptProtectedSyncReportPath -PathType Leaf)) {
-          throw ("Protected sync report not found: {0}" -f $attemptProtectedSyncReportPath)
-        }
-        $attemptProtectedSync = Get-Content -LiteralPath $attemptProtectedSyncReportPath -Raw | ConvertFrom-Json -AsHashtable
-        $attemptSyncMode = [string]($attemptProtectedSync['syncMethod'] ?? 'protected-pr')
-        if ($attemptSyncMode -eq 'fork-sync') {
-          Remove-RemoteBranchWithTransportFallback -Remote $HeadRemote -BranchName $syncBranch
-          $attemptPushTransport = $null
-        }
-      }
-
       $localHead = Get-GitValue -Arguments @('rev-parse', 'HEAD')
+      $targetRepository = Resolve-RemoteRepositorySlug -Remote $HeadRemote
+      $activeRuleTypes = @()
+      $protectedSyncProbe = [ordered]@{
+        required = $false
+        ruleTypes = @()
+        rulesetIds = @()
+        bypassModes = @()
+        bypassAllowsDirectPush = $false
+      }
+      if (-not [string]::IsNullOrWhiteSpace($targetRepository)) {
+        $protectedSyncProbe = Get-ActiveProtectedSyncProbe -Repository $targetRepository -BranchName $Branch
+        $activeRuleTypes = @($protectedSyncProbe.ruleTypes)
+      }
+      if ($protectedSyncProbe.required) {
+        $attemptSyncReason = 'protected-branch-rules'
+        $protectedSyncResult = Invoke-ProtectedBranchSync -RepoRoot $repoRoot -BaseRemote $BaseRemote -HeadRemote $HeadRemote -BranchName $Branch -Reason $attemptSyncReason -LocalHead $localHead -RuleTypes $activeRuleTypes
+        $attemptPushTransport = $protectedSyncResult.pushTransport
+        $attemptProtectedSyncReportPath = $protectedSyncResult.protectedSyncReportPath
+        $attemptProtectedSync = $protectedSyncResult.protectedSync
+        $attemptSyncMode = $protectedSyncResult.syncMethod
+      } else {
+        if ($protectedSyncProbe.bypassAllowsDirectPush -and $activeRuleTypes.Count -gt 0) {
+          Write-Host ("[sync] Active branch rules exist for {0}/{1}, but the current actor can bypass them ({2}); continuing with direct push detection." -f $HeadRemote, $Branch, ($protectedSyncProbe.bypassModes -join ', '))
+        }
+        try {
+          $attemptPushTransport = Invoke-PushWithTransportFallback -Remote $HeadRemote -BranchName $Branch
+        }
+        catch {
+          $message = $_.Exception.Message
+          if (-not (Test-GitHubProtectedBranchFailure -Message $message)) {
+            throw
+          }
+
+          $attemptSyncReason = Get-ProtectedBranchSyncReason -Message $message
+          $protectedSyncResult = Invoke-ProtectedBranchSync -RepoRoot $repoRoot -BaseRemote $BaseRemote -HeadRemote $HeadRemote -BranchName $Branch -Reason $attemptSyncReason -LocalHead $localHead
+          $attemptPushTransport = $protectedSyncResult.pushTransport
+          $attemptProtectedSyncReportPath = $protectedSyncResult.protectedSyncReportPath
+          $attemptProtectedSync = $protectedSyncResult.protectedSync
+          $attemptSyncMode = $protectedSyncResult.syncMethod
+        }
+      }
+
       if ([string]::IsNullOrWhiteSpace($localHead)) {
         throw 'Unable to resolve local HEAD after push.'
       }

--- a/tools/priority/__tests__/develop-sync.test.mjs
+++ b/tools/priority/__tests__/develop-sync.test.mjs
@@ -150,6 +150,21 @@ test('Sync-OriginUpstreamDevelop routes GH013 through protected sync helper path
   const scriptPath = path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1');
   const source = readFileSyncImmediate(scriptPath, 'utf8');
 
+  assert.match(source, /function Resolve-RemoteRepositorySlug/);
+  assert.match(source, /function Get-ActiveBranchRules/);
+  assert.match(source, /function Get-ActiveBranchRuleTypes/);
+  assert.match(source, /function Get-ActiveBranchRulesetIds/);
+  assert.match(source, /function Get-RulesetCurrentUserBypassMode/);
+  assert.match(source, /function Get-ActiveProtectedSyncProbe/);
+  assert.match(source, /function Test-ActiveBranchRulesRequireProtectedSync/);
+  assert.match(source, /function Invoke-ProtectedBranchSync/);
+  assert.match(source, /rules\/branches\/\{1\}/);
+  assert.match(source, /rulesets\/\{1\}/);
+  assert.match(source, /EscapeDataString\(\$BranchName\)/);
+  assert.match(source, /return 'unknown'/);
+  assert.match(source, /Active branch rules require protected sync for \{0\}\/\{1\}; routing through protected sync helper/);
+  assert.match(source, /current actor can bypass them/);
+  assert.match(source, /protected-branch-rules/);
   assert.match(source, /function Test-GitHubProtectedBranchFailure/);
   assert.match(source, /function Get-ProtectedBranchSyncReason/);
   assert.match(source, /GH013/);
@@ -161,8 +176,8 @@ test('Sync-OriginUpstreamDevelop routes GH013 through protected sync helper path
   assert.match(source, /Protected sync staged via PR path/);
   assert.match(source, /\$attemptSyncReason = Get-ProtectedBranchSyncReason -Message \$message/);
   assert.match(source, /\$attemptSyncMode = 'direct-push'/);
-  assert.match(source, /\$attemptSyncMode = \[string\]\(\$attemptProtectedSync\['syncMethod'\] \?\? 'protected-pr'\)/);
-  assert.match(source, /if \(\$attemptSyncMode -eq 'fork-sync'\)/);
+  assert.match(source, /\$attemptSyncMode = \$protectedSyncResult\.syncMethod/);
+  assert.match(source, /if \(\$syncMethod -eq 'fork-sync'\)/);
   assert.match(source, /Remove-RemoteBranchWithTransportFallback -Remote \$HeadRemote -BranchName \$syncBranch/);
   assert.match(source, /\$syncMode = \$attemptSyncMode/);
   assert.match(source, /if \(\$tipDiffCount -ne 0 -and \$syncMode -eq 'protected-pr'\)/);
@@ -182,10 +197,7 @@ test('buildSyncAdminPaths uses git-common-dir for repo-wide lock serialization i
 
   assert.equal(adminPaths.gitCommonDir, expectedGitCommonDir);
   assert.equal(adminPaths.lockPath, expectedLockPath);
-  assert.notEqual(
-    adminPaths.lockPath,
-    path.join(repoRoot, '.git', buildSyncLockName({ baseRemote: 'upstream', headRemote: 'origin', branch: 'develop' }))
-  );
+  assert.equal(adminPaths.lockPath.startsWith(adminPaths.gitCommonDir), true);
 });
 
 test('runDevelopSync writes admin-path diagnostics when the underlying sync command fails', async (t) => {
@@ -784,6 +796,332 @@ test('Sync-OriginUpstreamDevelop targeted refresh detects a newer remote head in
 
   assert.notEqual(result.status, 0);
   assert.match(`${result.stdout}\n${result.stderr}`, /Remote tracking ref .* expected/);
+});
+
+test('Sync-OriginUpstreamDevelop treats active branch rules as a protected sync PR handoff before direct push', async (t) => {
+  const sandboxRoot = await mkdtemp(path.join(os.tmpdir(), 'develop-sync-protected-rules-'));
+  const upstreamBare = path.join(sandboxRoot, 'upstream.git');
+  const originBare = path.join(sandboxRoot, 'origin.git');
+  const seedRepo = path.join(sandboxRoot, 'seed');
+  const controlRepo = path.join(sandboxRoot, 'control');
+  const worktreeRepo = path.join(sandboxRoot, 'worktree');
+  const updaterRepo = path.join(sandboxRoot, 'updater');
+  t.after(async () => {
+    await rm(sandboxRoot, { recursive: true, force: true });
+  });
+
+  initBareRepo(upstreamBare);
+  initBareRepo(originBare);
+
+  initRepo(seedRepo);
+  await writeFile(path.join(seedRepo, 'README.md'), 'seed\n', 'utf8');
+  run('git', ['add', 'README.md'], { cwd: seedRepo });
+  run('git', ['commit', '-m', 'seed'], { cwd: seedRepo });
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: seedRepo });
+  run('git', ['remote', 'add', 'origin', originBare], { cwd: seedRepo });
+  run('git', ['push', 'upstream', 'develop'], { cwd: seedRepo });
+  run('git', ['push', 'origin', 'develop'], { cwd: seedRepo });
+
+  run('git', ['clone', originBare, controlRepo], { cwd: sandboxRoot });
+  run('git', ['config', 'user.email', 'agent@example.com'], { cwd: controlRepo });
+  run('git', ['config', 'user.name', 'Agent Runner'], { cwd: controlRepo });
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: controlRepo });
+  run('git', ['fetch', 'upstream'], { cwd: controlRepo });
+  run('git', ['worktree', 'add', '-b', 'issue/test-sync-protected-rules', worktreeRepo, 'develop'], { cwd: controlRepo });
+  run('git', ['checkout', '--detach'], { cwd: controlRepo });
+
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority', 'lib'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'policy'), { recursive: true });
+  const source = readFileSyncImmediate(path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'), 'utf8');
+  const protectedSource = source
+    .replace(
+      "$targetRepository = Resolve-RemoteRepositorySlug -Remote $HeadRemote",
+      "$targetRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'"
+    )
+    .replace(
+      "$protectedSyncProbe = Get-ActiveProtectedSyncProbe -Repository $targetRepository -BranchName $Branch",
+      "$protectedSyncProbe = [ordered]@{ required = $true; ruleTypes = @('pull_request', 'merge_queue'); rulesetIds = @('13700055'); bypassModes = @('never'); bypassAllowsDirectPush = $false }"
+    );
+  await writeFile(path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'), protectedSource, 'utf8');
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'report-origin-upstream-parity.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'report-origin-upstream-parity.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'lib', 'branch-classification.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'lib', 'branch-classification.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    path.join(worktreeRepo, 'tools', 'policy', 'branch-classes.json')
+  );
+  await writeFile(
+    path.join(worktreeRepo, 'tools', 'priority', 'protected-develop-sync-pr.mjs'),
+    `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+const reportIndex = args.indexOf('--report-path');
+const reportPath = reportIndex >= 0 ? args[reportIndex + 1] : path.join(process.cwd(), 'tests/results/_agent/issue/protected-report.json');
+const syncIndex = args.indexOf('--sync-branch');
+const syncBranch = syncIndex >= 0 ? args[syncIndex + 1] : 'sync/origin-develop';
+mkdirSync(path.dirname(reportPath), { recursive: true });
+writeFileSync(reportPath, JSON.stringify({
+  schema: 'priority/protected-develop-sync@v1',
+  generatedAt: '2026-03-12T00:00:00.000Z',
+  targetRemote: 'origin',
+  baseRemote: 'upstream',
+  branch: 'develop',
+  syncBranch,
+  reason: 'protected-branch-rules',
+  planeTransition: {
+    from: 'upstream',
+    to: 'origin',
+    action: 'sync',
+    via: 'priority:develop:sync'
+  },
+  pullRequest: {
+    number: 56,
+    url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action-fork/pull/56',
+    isDraft: false,
+    mergeStateStatus: 'BLOCKED',
+    reusedExisting: false
+  },
+  readyState: { status: 'marked-ready' },
+  mergeRequest: { status: 'requested' }
+}, null, 2) + '\\n', 'utf8');
+`,
+    'utf8'
+  );
+
+  run('git', ['clone', upstreamBare, updaterRepo], { cwd: sandboxRoot });
+  run('git', ['config', 'user.email', 'agent@example.com'], { cwd: updaterRepo });
+  run('git', ['config', 'user.name', 'Agent Runner'], { cwd: updaterRepo });
+  await writeFile(path.join(updaterRepo, 'CHANGE.txt'), 'upstream advance\n', 'utf8');
+  run('git', ['add', 'CHANGE.txt'], { cwd: updaterRepo });
+  run('git', ['commit', '-m', 'advance upstream'], { cwd: updaterRepo });
+  run('git', ['push', 'origin', 'develop'], { cwd: updaterRepo });
+
+  const parityReportPath = path.join(worktreeRepo, 'tests', 'results', '_agent', 'issue', 'origin-upstream-parity.json');
+  run(
+    'pwsh',
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-File',
+      path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'),
+      '-HeadRemote',
+      'origin',
+      '-ParityReportPath',
+      parityReportPath
+    ],
+    { cwd: worktreeRepo, timeout: 180000 }
+  );
+
+  const upstreamHead = run('git', ['--git-dir', upstreamBare, 'rev-parse', 'develop'], { cwd: sandboxRoot });
+  const originDevelopHead = run('git', ['--git-dir', originBare, 'rev-parse', 'develop'], { cwd: sandboxRoot });
+  const syncBranchHead = run('git', ['--git-dir', originBare, 'rev-parse', 'refs/heads/sync/origin-develop'], { cwd: sandboxRoot });
+  assert.notEqual(originDevelopHead, upstreamHead);
+  assert.equal(syncBranchHead, upstreamHead);
+
+  const parityReport = JSON.parse(await readFile(parityReportPath, 'utf8'));
+  assert.equal(parityReport.planeTransition.from, 'upstream');
+  assert.equal(parityReport.planeTransition.to, 'origin');
+  assert.equal(parityReport.syncResult.mode, 'protected-pr');
+  assert.equal(parityReport.syncResult.reason, 'protected-branch-rules');
+  assert.equal(parityReport.syncResult.parityConverged, false);
+  assert.equal(parityReport.syncResult.planeTransition.to, 'origin');
+  assert.equal(parityReport.syncResult.protectedSync.pullRequest.number, 56);
+  assert.equal(parityReport.tipDiff.fileCount > 0, true);
+});
+
+test('Sync-OriginUpstreamDevelop keeps direct-push mode when active rules are bypassable by the current actor', async (t) => {
+  const sandboxRoot = await mkdtemp(path.join(os.tmpdir(), 'develop-sync-protected-bypass-'));
+  const upstreamBare = path.join(sandboxRoot, 'upstream.git');
+  const originBare = path.join(sandboxRoot, 'origin.git');
+  const seedRepo = path.join(sandboxRoot, 'seed');
+  const controlRepo = path.join(sandboxRoot, 'control');
+  const worktreeRepo = path.join(sandboxRoot, 'worktree');
+  const updaterRepo = path.join(sandboxRoot, 'updater');
+  t.after(async () => {
+    await rm(sandboxRoot, { recursive: true, force: true });
+  });
+
+  initBareRepo(upstreamBare);
+  initBareRepo(originBare);
+
+  initRepo(seedRepo);
+  await writeFile(path.join(seedRepo, 'README.md'), 'seed\n', 'utf8');
+  run('git', ['add', 'README.md'], { cwd: seedRepo });
+  run('git', ['commit', '-m', 'seed'], { cwd: seedRepo });
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: seedRepo });
+  run('git', ['remote', 'add', 'origin', originBare], { cwd: seedRepo });
+  run('git', ['push', 'upstream', 'develop'], { cwd: seedRepo });
+  run('git', ['push', 'origin', 'develop'], { cwd: seedRepo });
+
+  run('git', ['clone', originBare, controlRepo], { cwd: sandboxRoot });
+  run('git', ['config', 'user.email', 'agent@example.com'], { cwd: controlRepo });
+  run('git', ['config', 'user.name', 'Agent Runner'], { cwd: controlRepo });
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: controlRepo });
+  run('git', ['fetch', 'upstream'], { cwd: controlRepo });
+  run('git', ['worktree', 'add', '-b', 'issue/test-sync-protected-bypass', worktreeRepo, 'develop'], { cwd: controlRepo });
+  run('git', ['checkout', '--detach'], { cwd: controlRepo });
+
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority', 'lib'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'policy'), { recursive: true });
+  const source = readFileSyncImmediate(path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'), 'utf8');
+  const bypassSource = source
+    .replace(
+      "$targetRepository = Resolve-RemoteRepositorySlug -Remote $HeadRemote",
+      "$targetRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'"
+    )
+    .replace(
+      "$protectedSyncProbe = Get-ActiveProtectedSyncProbe -Repository $targetRepository -BranchName $Branch",
+      "$protectedSyncProbe = [ordered]@{ required = $false; ruleTypes = @('pull_request', 'merge_queue'); rulesetIds = @('13700055'); bypassModes = @('always'); bypassAllowsDirectPush = $true }"
+    );
+  await writeFile(path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'), bypassSource, 'utf8');
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'report-origin-upstream-parity.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'report-origin-upstream-parity.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'lib', 'branch-classification.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'lib', 'branch-classification.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    path.join(worktreeRepo, 'tools', 'policy', 'branch-classes.json')
+  );
+
+  run('git', ['clone', upstreamBare, updaterRepo], { cwd: sandboxRoot });
+  run('git', ['config', 'user.email', 'agent@example.com'], { cwd: updaterRepo });
+  run('git', ['config', 'user.name', 'Agent Runner'], { cwd: updaterRepo });
+  await writeFile(path.join(updaterRepo, 'CHANGE.txt'), 'upstream advance\n', 'utf8');
+  run('git', ['add', 'CHANGE.txt'], { cwd: updaterRepo });
+  run('git', ['commit', '-m', 'advance upstream'], { cwd: updaterRepo });
+  run('git', ['push', 'origin', 'develop'], { cwd: updaterRepo });
+
+  const parityReportPath = path.join(worktreeRepo, 'tests', 'results', '_agent', 'issue', 'origin-upstream-parity.json');
+  run(
+    'pwsh',
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-File',
+      path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'),
+      '-HeadRemote',
+      'origin',
+      '-ParityReportPath',
+      parityReportPath
+    ],
+    { cwd: worktreeRepo, timeout: 180000 }
+  );
+
+  const upstreamHead = run('git', ['--git-dir', upstreamBare, 'rev-parse', 'develop'], { cwd: sandboxRoot });
+  const originDevelopHead = run('git', ['--git-dir', originBare, 'rev-parse', 'develop'], { cwd: sandboxRoot });
+  assert.equal(originDevelopHead, upstreamHead);
+
+  const parityReport = JSON.parse(await readFile(parityReportPath, 'utf8'));
+  assert.equal(parityReport.syncResult.mode, 'direct-push');
+  assert.equal(parityReport.syncResult.reason, 'direct-push');
+  assert.equal(parityReport.syncResult.parityConverged, true);
+  assert.equal(parityReport.tipDiff.fileCount, 0);
+});
+
+test('Sync-OriginUpstreamDevelop keeps direct-push mode when bypass authority is unknown', async (t) => {
+  const sandboxRoot = await mkdtemp(path.join(os.tmpdir(), 'develop-sync-protected-unknown-'));
+  const upstreamBare = path.join(sandboxRoot, 'upstream.git');
+  const originBare = path.join(sandboxRoot, 'origin.git');
+  const seedRepo = path.join(sandboxRoot, 'seed');
+  const controlRepo = path.join(sandboxRoot, 'control');
+  const worktreeRepo = path.join(sandboxRoot, 'worktree');
+  const updaterRepo = path.join(sandboxRoot, 'updater');
+  t.after(async () => {
+    await rm(sandboxRoot, { recursive: true, force: true });
+  });
+
+  initBareRepo(upstreamBare);
+  initBareRepo(originBare);
+
+  initRepo(seedRepo);
+  await writeFile(path.join(seedRepo, 'README.md'), 'seed\n', 'utf8');
+  run('git', ['add', 'README.md'], { cwd: seedRepo });
+  run('git', ['commit', '-m', 'seed'], { cwd: seedRepo });
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: seedRepo });
+  run('git', ['remote', 'add', 'origin', originBare], { cwd: seedRepo });
+  run('git', ['push', 'upstream', 'develop'], { cwd: seedRepo });
+  run('git', ['push', 'origin', 'develop'], { cwd: seedRepo });
+
+  run('git', ['clone', originBare, controlRepo], { cwd: sandboxRoot });
+  run('git', ['config', 'user.email', 'agent@example.com'], { cwd: controlRepo });
+  run('git', ['config', 'user.name', 'Agent Runner'], { cwd: controlRepo });
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: controlRepo });
+  run('git', ['fetch', 'upstream'], { cwd: controlRepo });
+  run('git', ['worktree', 'add', '-b', 'issue/test-sync-protected-unknown', worktreeRepo, 'develop'], { cwd: controlRepo });
+  run('git', ['checkout', '--detach'], { cwd: controlRepo });
+
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority', 'lib'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'policy'), { recursive: true });
+  const source = readFileSyncImmediate(path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'), 'utf8');
+  const unknownSource = source
+    .replace(
+      "$targetRepository = Resolve-RemoteRepositorySlug -Remote $HeadRemote",
+      "$targetRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'"
+    )
+    .replace(
+      "$protectedSyncProbe = Get-ActiveProtectedSyncProbe -Repository $targetRepository -BranchName $Branch",
+      "$protectedSyncProbe = [ordered]@{ required = $false; ruleTypes = @('pull_request', 'merge_queue'); rulesetIds = @('13700055'); bypassModes = @('unknown'); bypassAllowsDirectPush = $false }"
+    );
+  await writeFile(path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'), unknownSource, 'utf8');
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'report-origin-upstream-parity.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'report-origin-upstream-parity.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'lib', 'branch-classification.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'lib', 'branch-classification.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    path.join(worktreeRepo, 'tools', 'policy', 'branch-classes.json')
+  );
+
+  run('git', ['clone', upstreamBare, updaterRepo], { cwd: sandboxRoot });
+  run('git', ['config', 'user.email', 'agent@example.com'], { cwd: updaterRepo });
+  run('git', ['config', 'user.name', 'Agent Runner'], { cwd: updaterRepo });
+  await writeFile(path.join(updaterRepo, 'CHANGE.txt'), 'upstream advance\n', 'utf8');
+  run('git', ['add', 'CHANGE.txt'], { cwd: updaterRepo });
+  run('git', ['commit', '-m', 'advance upstream'], { cwd: updaterRepo });
+  run('git', ['push', 'origin', 'develop'], { cwd: updaterRepo });
+
+  const parityReportPath = path.join(worktreeRepo, 'tests', 'results', '_agent', 'issue', 'origin-upstream-parity.json');
+  run(
+    'pwsh',
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-File',
+      path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'),
+      '-HeadRemote',
+      'origin',
+      '-ParityReportPath',
+      parityReportPath
+    ],
+    { cwd: worktreeRepo, timeout: 180000 }
+  );
+
+  const upstreamHead = run('git', ['--git-dir', upstreamBare, 'rev-parse', 'develop'], { cwd: sandboxRoot });
+  const originDevelopHead = run('git', ['--git-dir', originBare, 'rev-parse', 'develop'], { cwd: sandboxRoot });
+  assert.equal(originDevelopHead, upstreamHead);
+
+  const parityReport = JSON.parse(await readFile(parityReportPath, 'utf8'));
+  assert.equal(parityReport.syncResult.mode, 'direct-push');
+  assert.equal(parityReport.syncResult.reason, 'direct-push');
+  assert.equal(parityReport.syncResult.parityConverged, true);
+  assert.equal(parityReport.tipDiff.fileCount, 0);
 });
 
 test('Sync-OriginUpstreamDevelop treats GH013 as a protected sync PR handoff instead of failing', async (t) => {


### PR DESCRIPTION
# Summary

Delivers fork issue #6 by teaching `priority:develop:sync` to distinguish direct-push sync from protected PR/merge-queue sync and to fail closed when a protected path cannot be staged.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #6
- Repository scope: `LabVIEW-Community-CI-CD/compare-vi-cli-action-fork`
- Files touched:
  - `tools/priority/Sync-OriginUpstreamDevelop.ps1`
  - `tools/priority/__tests__/develop-sync.test.mjs`
- Behavior change:
  - active protected branch rules can preempt direct push and stage a protected sync PR path
  - actor-bypassable or inconclusive rule probes remain on deterministic direct-push detection
  - sync reports now distinguish `direct-push` from protected PR/queue staging metadata

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/develop-sync.test.mjs tools/priority/__tests__/protected-develop-sync-pr.test.mjs`
  - `git diff --check`
  - `node tools/npm/run-script.mjs priority:develop:sync -- --fork-remote origin`
  - `node tools/npm/run-script.mjs priority:policy:apply`
- Key artifacts:
  - `tests/results/_agent/issue/develop-sync-report.json`
  - `tests/results/_agent/issue/origin-upstream-parity.json`
  - `tests/results/_agent/policy/policy-drift-report.json`
- Copilot CLI:
  - `node tools/priority/copilot-cli-review.mjs --profile pre-commit --receipt-path tests/results/_agent/reviews/protected-develop-sync-6-bounded-receipt.json`
  - final receipt: `passed`
  - receipt path: `tests/results/_agent/reviews/protected-develop-sync-6-bounded-receipt.json`

## Risks and Follow-ups

- Residual risk: classic branch protection still uses the existing GH013 fallback path when active ruleset preflight is inconclusive.
- Follow-up scope remains outside this PR: future fork standing lanes `#10`, `#2`, and epic triage for `#1`.

Closes #6
