### PR TITLE
Emit branch-attributed cost turns for active PR lanes

### DIFF
--- a/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
+++ b/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
@@ -391,3 +391,38 @@ factors into one opaque number.
 
 Those should stay follow-up lanes. The first slice should stay anchored to
 existing repo-visible receipts.
+
+## Account-Backed Calibration Evidence
+
+`#1671` extends the roll-up layer so it can consume optional normalized account
+evidence without replacing invoice turns:
+
+- usage-export receipts under `tests/results/_agent/cost/usage-exports/`
+- account-balance receipts under `tests/results/_agent/cost/account-balances/`
+
+The roll-up now accepts:
+
+- `--usage-export <path>`
+- `--account-balance <path>`
+
+When those flags are omitted, the roll-up auto-discovers JSON receipts from the
+default directories above. Valid receipts are summarized into:
+
+- `summary.metrics.usageExportWindowCount`
+- `summary.metrics.usageExportCreditsReported`
+- `summary.metrics.usageExportQuantityReported`
+- `summary.metrics.accountBalanceTotalCredits`
+- `summary.metrics.accountBalanceUsedCredits`
+- `summary.metrics.accountBalanceRemainingCredits`
+- `summary.provenance.usageExports`
+- `summary.provenance.accountBalance`
+
+This keeps the calibration layer honest:
+
+- invoice turns still define the selected funding window
+- usage exports provide account-window usage evidence
+- account balance snapshots provide current-plan total/used/remaining evidence
+
+These evidence receipts are optional. Missing directories do not fail the roll-
+up, but unreadable or schema-mismatched receipts do surface as blockers once
+they are present.

--- a/docs/schemas/agent-cost-account-balance-v1.schema.json
+++ b/docs/schemas/agent-cost-account-balance-v1.schema.json
@@ -4,11 +4,25 @@
   "title": "Agent Cost Account Balance Snapshot v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema", "generatedAt", "snapshotAt", "plan", "credits", "provenance"],
+  "required": [
+    "schema",
+    "generatedAt",
+    "effectiveAt",
+    "plan",
+    "balances",
+    "sourceSchema",
+    "sourceKind",
+    "sourcePathEvidence",
+    "confidence",
+    "operatorNote"
+  ],
   "properties": {
     "schema": { "const": "priority/agent-cost-account-balance@v1" },
     "generatedAt": { "type": "string", "format": "date-time" },
+    "effectiveAt": { "type": "string", "format": "date-time" },
+    "capturedAt": { "type": "string", "format": "date-time" },
     "snapshotAt": { "type": "string", "format": "date-time" },
+    "renewalCycleBoundaryAt": { "type": "string", "format": "date-time" },
     "plan": {
       "type": "object",
       "additionalProperties": false,
@@ -19,31 +33,23 @@
         "daysRemaining": { "type": "integer", "minimum": 0 }
       }
     },
-    "credits": {
+    "balances": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["total", "used", "remaining"],
+      "required": ["totalCredits", "usedCredits", "remainingCredits"],
       "properties": {
-        "total": { "type": "integer", "minimum": 0 },
-        "used": { "type": "integer", "minimum": 0 },
-        "remaining": { "type": "integer", "minimum": 0 }
+        "totalCredits": { "type": "integer", "minimum": 0 },
+        "usedCredits": { "type": "integer", "minimum": 0 },
+        "remainingCredits": { "type": "integer", "minimum": 0 }
       }
     },
-    "provenance": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["sourceSchema", "sourceKind", "sourcePath", "observedAt", "confidence", "operatorNote"],
-      "properties": {
-        "sourceSchema": { "type": ["string", "null"], "minLength": 1 },
-        "sourceKind": {
-          "type": "string",
-          "enum": ["operator-account-state", "billing-export", "manual-baseline"]
-        },
-        "sourcePath": { "type": "string", "minLength": 1 },
-        "observedAt": { "type": "string", "format": "date-time" },
-        "confidence": { "type": "string", "enum": ["low", "medium", "high"] },
-        "operatorNote": { "type": "string", "minLength": 1 }
-      }
-    }
+    "sourceSchema": { "type": "string", "minLength": 1 },
+    "sourceKind": {
+      "type": "string",
+      "enum": ["operator-account-state", "billing-export", "manual-baseline"]
+    },
+    "sourcePathEvidence": { "type": "string", "minLength": 1 },
+    "confidence": { "type": "string", "enum": ["low", "medium", "high"] },
+    "operatorNote": { "type": "string", "minLength": 1 }
   }
 }

--- a/docs/schemas/agent-cost-rollup-v1.schema.json
+++ b/docs/schemas/agent-cost-rollup-v1.schema.json
@@ -12,13 +12,21 @@
     "inputs": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["turnReportPaths", "invoiceTurnPaths", "selectedInvoiceTurnId", "explicitInvoiceTurnId"],
+      "required": ["turnReportPaths", "invoiceTurnPaths", "usageExportPaths", "accountBalancePaths", "selectedInvoiceTurnId", "explicitInvoiceTurnId"],
       "properties": {
         "turnReportPaths": {
           "type": "array",
           "items": { "$ref": "#/$defs/inputRef" }
         },
         "invoiceTurnPaths": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/inputRef" }
+        },
+        "usageExportPaths": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/inputRef" }
+        },
+        "accountBalancePaths": {
           "type": "array",
           "items": { "$ref": "#/$defs/inputRef" }
         },
@@ -257,6 +265,66 @@
         "reason": { "$ref": "#/$defs/nullableString" }
       }
     },
+    "usageExportSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourcePath",
+        "generatedAt",
+        "startDate",
+        "endDate",
+        "rowCount",
+        "usageType",
+        "usageCredits",
+        "usageQuantity",
+        "sourceKind",
+        "sourcePathEvidence",
+        "operatorNote"
+      ],
+      "properties": {
+        "sourcePath": { "type": "string", "minLength": 1 },
+        "generatedAt": { "$ref": "#/$defs/nullableString" },
+        "startDate": { "$ref": "#/$defs/nullableString" },
+        "endDate": { "$ref": "#/$defs/nullableString" },
+        "rowCount": { "type": ["integer", "null"], "minimum": 0 },
+        "usageType": { "$ref": "#/$defs/nullableString" },
+        "usageCredits": { "type": "number", "minimum": 0 },
+        "usageQuantity": { "type": "number", "minimum": 0 },
+        "sourceKind": { "$ref": "#/$defs/nullableString" },
+        "sourcePathEvidence": { "$ref": "#/$defs/nullableString" },
+        "operatorNote": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "accountBalanceSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourcePath",
+        "generatedAt",
+        "snapshotAt",
+        "planName",
+        "renewsAt",
+        "totalCredits",
+        "usedCredits",
+        "remainingCredits",
+        "sourceKind",
+        "sourcePathEvidence",
+        "operatorNote"
+      ],
+      "properties": {
+        "sourcePath": { "type": "string", "minLength": 1 },
+        "generatedAt": { "$ref": "#/$defs/nullableString" },
+        "snapshotAt": { "$ref": "#/$defs/nullableString" },
+        "planName": { "$ref": "#/$defs/nullableString" },
+        "renewsAt": { "$ref": "#/$defs/nullableString" },
+        "totalCredits": { "type": "number", "minimum": 0 },
+        "usedCredits": { "type": "number", "minimum": 0 },
+        "remainingCredits": { "type": "number", "minimum": 0 },
+        "sourceKind": { "$ref": "#/$defs/nullableString" },
+        "sourcePathEvidence": { "$ref": "#/$defs/nullableString" },
+        "operatorNote": { "$ref": "#/$defs/nullableString" }
+      }
+    },
     "summary": {
       "type": "object",
       "additionalProperties": false,
@@ -299,7 +367,13 @@
             "actualCreditsConsumed",
             "heuristicUsdDelta",
             "heuristicUsdDeltaRatio",
-            "heuristicCreditsDelta"
+            "heuristicCreditsDelta",
+            "usageExportWindowCount",
+            "usageExportCreditsReported",
+            "usageExportQuantityReported",
+            "accountBalanceTotalCredits",
+            "accountBalanceUsedCredits",
+            "accountBalanceRemainingCredits"
           ],
           "properties": {
             "totalTurns": { "type": "integer", "minimum": 0 },
@@ -325,13 +399,19 @@
             "actualCreditsConsumed": { "type": ["number", "null"], "minimum": 0 },
             "heuristicUsdDelta": { "type": ["number", "null"] },
             "heuristicUsdDeltaRatio": { "type": ["number", "null"] },
-            "heuristicCreditsDelta": { "type": ["number", "null"] }
+            "heuristicCreditsDelta": { "type": ["number", "null"] },
+            "usageExportWindowCount": { "type": "integer", "minimum": 0 },
+            "usageExportCreditsReported": { "type": "number", "minimum": 0 },
+            "usageExportQuantityReported": { "type": "number", "minimum": 0 },
+            "accountBalanceTotalCredits": { "type": ["number", "null"], "minimum": 0 },
+            "accountBalanceUsedCredits": { "type": ["number", "null"], "minimum": 0 },
+            "accountBalanceRemainingCredits": { "type": ["number", "null"], "minimum": 0 }
           }
         },
         "provenance": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["sessionIds", "issueNumbers", "laneIds", "repositories", "rateCards", "reasoningEfforts", "steeringKinds", "steeringSources", "invoiceTurn", "invoiceTurnSelection", "invoiceTurns"],
+          "required": ["sessionIds", "issueNumbers", "laneIds", "repositories", "rateCards", "reasoningEfforts", "steeringKinds", "steeringSources", "invoiceTurn", "invoiceTurnSelection", "invoiceTurns", "usageExports", "accountBalance"],
           "properties": {
             "sessionIds": { "type": "array", "items": { "type": "string" } },
             "issueNumbers": { "type": "array", "items": { "type": "integer", "minimum": 0 } },
@@ -364,6 +444,16 @@
             "invoiceTurns": {
               "type": "array",
               "items": { "$ref": "#/$defs/invoiceTurnSummary" }
+            },
+            "usageExports": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/usageExportSummary" }
+            },
+            "accountBalance": {
+              "anyOf": [
+                { "$ref": "#/$defs/accountBalanceSummary" },
+                { "type": "null" }
+              ]
             }
           }
         }

--- a/tools/priority/__fixtures__/agent-cost-rollup/private-account-balance-sample.json
+++ b/tools/priority/__fixtures__/agent-cost-rollup/private-account-balance-sample.json
@@ -1,20 +1,21 @@
 {
   "schema": "priority/agent-cost-private-account-balance@v1",
   "snapshotAt": "2026-03-21T12:00:00.000Z",
+  "capturedAt": "2026-03-21T12:00:00.000Z",
+  "effectiveAt": "2026-03-21T12:00:00.000Z",
+  "renewalCycleBoundaryAt": "2026-04-15T00:00:00.000Z",
   "plan": {
     "name": "business",
     "renewsAt": "2026-04-15"
   },
-  "credits": {
-    "total": 27500,
-    "used": 15800,
-    "remaining": 11700
+  "balances": {
+    "totalCredits": 27500,
+    "usedCredits": 15800,
+    "remainingCredits": 11700
   },
-  "provenance": {
-    "sourceKind": "operator-account-state",
-    "sourcePath": "C:/Users/operator/Downloads/account-balance-20260321.json",
-    "observedAt": "2026-03-21T12:00:00.000Z",
-    "confidence": "high",
-    "operatorNote": "Sanitized operator-provided account balance snapshot."
-  }
+  "sourceSchema": "priority/agent-cost-private-account-balance@v1",
+  "sourceKind": "operator-account-state",
+  "sourcePathEvidence": "tools/priority/__fixtures__/agent-cost-rollup/private-account-balance-sample.json",
+  "confidence": "high",
+  "operatorNote": "Sanitized operator-provided account balance snapshot."
 }

--- a/tools/priority/__tests__/agent-cost-account-balance-normalize.test.mjs
+++ b/tools/priority/__tests__/agent-cost-account-balance-normalize.test.mjs
@@ -15,6 +15,15 @@ import {
 
 const repoRoot = path.resolve(process.cwd());
 const fixtureRoot = path.join(repoRoot, 'tools', 'priority', '__fixtures__', 'agent-cost-rollup');
+const canonicalOutputPath = path.join(
+  repoRoot,
+  'tests',
+  'results',
+  '_agent',
+  'cost',
+  'account-balances',
+  'account-balance-2026-03-21.json'
+);
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -39,17 +48,22 @@ test('buildNormalizedAccountBalanceReceiptFromSnapshot normalizes a private acco
   const report = buildNormalizedAccountBalanceReceiptFromSnapshot(snapshot);
 
   assert.equal(report.schema, 'priority/agent-cost-account-balance@v1');
-  assert.equal(report.snapshotAt, '2026-03-21T12:00:00.000Z');
+  assert.equal(report.effectiveAt, '2026-03-21T12:00:00.000Z');
+  assert.equal(report.capturedAt, '2026-03-21T12:00:00.000Z');
+  assert.equal(report.renewalCycleBoundaryAt, '2026-04-15T00:00:00.000Z');
   assert.equal(report.plan.name, 'business');
   assert.equal(report.plan.renewsAt, '2026-04-15');
   assert.equal(report.plan.daysRemaining, 25);
-  assert.equal(report.credits.total, 27500);
-  assert.equal(report.credits.used, 15800);
-  assert.equal(report.credits.remaining, 11700);
-  assert.equal(report.provenance.sourceSchema, 'priority/agent-cost-private-account-balance@v1');
-  assert.equal(report.provenance.sourceKind, 'operator-account-state');
-  assert.equal(report.provenance.observedAt, '2026-03-21T12:00:00.000Z');
-  assert.equal(report.provenance.confidence, 'high');
+  assert.deepEqual(report.balances, {
+    totalCredits: 27500,
+    usedCredits: 15800,
+    remainingCredits: 11700
+  });
+  assert.equal(report.sourceSchema, 'priority/agent-cost-private-account-balance@v1');
+  assert.equal(report.sourceKind, 'operator-account-state');
+  assert.equal(report.sourcePathEvidence, 'tools/priority/__fixtures__/agent-cost-rollup/private-account-balance-sample.json');
+  assert.equal(report.confidence, 'high');
+  assert.equal(report.operatorNote, 'Sanitized operator-provided account balance snapshot.');
 });
 
 test('runAgentCostAccountBalanceNormalize writes a normalized account-balance receipt to the requested path', () => {
@@ -60,8 +74,29 @@ test('runAgentCostAccountBalanceNormalize writes a normalized account-balance re
     outputPath
   });
 
-  assert.equal(result.report.credits.remaining, 11700);
+  assert.deepEqual(result.report.balances, {
+    totalCredits: 27500,
+    usedCredits: 15800,
+    remainingCredits: 11700
+  });
   assert.equal(fs.existsSync(outputPath), true);
+});
+
+test('runAgentCostAccountBalanceNormalize auto-discovers the canonical account-balance output path when none is provided', () => {
+  if (fs.existsSync(canonicalOutputPath)) {
+    fs.rmSync(canonicalOutputPath, { force: true });
+  }
+
+  try {
+    const result = runAgentCostAccountBalanceNormalize({
+      snapshotPath: path.join(fixtureRoot, 'private-account-balance-sample.json')
+    });
+
+    assert.equal(result.outputPath, canonicalOutputPath);
+    assert.equal(fs.existsSync(canonicalOutputPath), true);
+  } finally {
+    fs.rmSync(canonicalOutputPath, { force: true });
+  }
 });
 
 test('agent-cost-account-balance-normalize CLI writes a receipt directly', () => {

--- a/tools/priority/__tests__/agent-cost-rollup-schema.test.mjs
+++ b/tools/priority/__tests__/agent-cost-rollup-schema.test.mjs
@@ -17,6 +17,11 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
 test('agent cost turn fixtures and rollup report match the checked-in schemas', () => {
   const invoiceTurnSchema = readJson(path.join(repoRoot, 'docs', 'schemas', 'agent-cost-invoice-turn-v1.schema.json'));
   const turnSchema = readJson(path.join(repoRoot, 'docs', 'schemas', 'agent-cost-turn-v1.schema.json'));
@@ -51,6 +56,42 @@ test('agent cost turn fixtures and rollup report match the checked-in schemas', 
   }
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-rollup-schema-'));
+  const usageExportPath = path.join(tmpDir, 'usage-export.json');
+  const accountBalancePath = path.join(tmpDir, 'account-balance.json');
+  writeJson(usageExportPath, {
+    schema: 'priority/agent-cost-usage-export@v1',
+    generatedAt: '2026-03-21T20:20:00.000Z',
+    reportWindow: {
+      startDate: '2026-03-15',
+      endDate: '2026-03-20',
+      rowCount: 6
+    },
+    usageType: 'codex',
+    totals: {
+      usageCredits: 10559.88,
+      usageQuantity: 211197.6
+    },
+    sourceKind: 'operator-usage-export',
+    sourcePathEvidence: 'usage-export.csv',
+    operatorNote: 'Current partial usage window.'
+  });
+  writeJson(accountBalancePath, {
+    schema: 'priority/agent-cost-account-balance@v1',
+    generatedAt: '2026-03-21T20:21:00.000Z',
+    effectiveAt: '2026-03-21T20:21:00.000Z',
+    plan: {
+      name: 'Business',
+      renewsAt: '2026-04-15T00:00:00.000Z'
+    },
+    balances: {
+      totalCredits: 27500,
+      usedCredits: 15800,
+      remainingCredits: 11700
+    },
+    sourceKind: 'operator-account-balance',
+    sourcePathEvidence: 'account-balance',
+    operatorNote: 'Current account balance snapshot.'
+  });
   const result = runAgentCostRollup({
     repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
     turnReportPaths: [
@@ -58,6 +99,8 @@ test('agent cost turn fixtures and rollup report match the checked-in schemas', 
       path.join(fixtureRoot, 'background-turn-exact.json')
     ],
     invoiceTurnPaths: [path.join(fixtureRoot, 'invoice-turn-baseline.json')],
+    usageExportPaths: [usageExportPath],
+    accountBalancePaths: [accountBalancePath],
     outputPath: path.join(tmpDir, 'agent-cost-rollup.json')
   });
 

--- a/tools/priority/__tests__/agent-cost-rollup.test.mjs
+++ b/tools/priority/__tests__/agent-cost-rollup.test.mjs
@@ -31,6 +31,10 @@ test('parseArgs accepts repeated turn reports and optional repo override', () =>
     'invoice-a.json',
     '--invoice-turn',
     'invoice-b.json',
+    '--usage-export',
+    'usage-a.json',
+    '--account-balance',
+    'balance-a.json',
     '--invoice-turn-id',
     'invoice-turn-2026-03-HQ1VJLMV-0027',
     '--repo',
@@ -40,6 +44,8 @@ test('parseArgs accepts repeated turn reports and optional repo override', () =>
 
   assert.deepEqual(parsed.turnReportPaths, ['turn-a.json', 'turn-b.json']);
   assert.deepEqual(parsed.invoiceTurnPaths, ['invoice-a.json', 'invoice-b.json']);
+  assert.deepEqual(parsed.usageExportPaths, ['usage-a.json']);
+  assert.deepEqual(parsed.accountBalancePaths, ['balance-a.json']);
   assert.equal(parsed.invoiceTurnId, 'invoice-turn-2026-03-HQ1VJLMV-0027');
   assert.equal(parsed.repo, 'example/repo');
   assert.equal(parsed.failOnInvalidInputs, false);
@@ -227,6 +233,68 @@ test('estimated turns do not let a declared zero amount mask a computable rate-c
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.turns[0].amountUsd, 0.018);
   assert.equal(result.report.turns[0].amountSource, 'rate-card-estimate');
+});
+
+test('runAgentCostRollup summarizes optional usage-export and account-balance evidence', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-rollup-account-evidence-'));
+  const outputPath = path.join(tmpDir, 'agent-cost-rollup.json');
+  const usageExportPath = path.join(tmpDir, 'usage-export.json');
+  const accountBalancePath = path.join(tmpDir, 'account-balance.json');
+
+  writeJson(usageExportPath, {
+    schema: 'priority/agent-cost-usage-export@v1',
+    generatedAt: '2026-03-21T20:20:00.000Z',
+    reportWindow: {
+      startDate: '2026-03-15',
+      endDate: '2026-03-20',
+      rowCount: 6
+    },
+    usageType: 'codex',
+    totals: {
+      usageCredits: 10559.88,
+      usageQuantity: 211197.6
+    },
+    sourceKind: 'operator-usage-export',
+    sourcePathEvidence: 'LabVIEW Open-Source Initiative Credit Usage Report (Mar 15 - Apr 15).csv',
+    operatorNote: 'Current partial usage window.'
+  });
+
+  writeJson(accountBalancePath, {
+    schema: 'priority/agent-cost-account-balance@v1',
+    generatedAt: '2026-03-21T20:21:00.000Z',
+    effectiveAt: '2026-03-21T20:21:00.000Z',
+    plan: {
+      name: 'Business',
+      renewsAt: '2026-04-15T00:00:00.000Z'
+    },
+    balances: {
+      totalCredits: 27500,
+      usedCredits: 15800,
+      remainingCredits: 11700
+    },
+    sourceKind: 'operator-account-balance',
+    sourcePathEvidence: 'Business plan account snapshot',
+    operatorNote: 'Current account balance snapshot.'
+  });
+
+  const result = runAgentCostRollup({
+    repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    turnReportPaths: [
+      path.join(fixtureRoot, 'live-turn-estimated.json'),
+      path.join(fixtureRoot, 'background-turn-exact.json')
+    ],
+    invoiceTurnPaths: [path.join(fixtureRoot, 'invoice-turn-baseline.json')],
+    usageExportPaths: [usageExportPath],
+    accountBalancePaths: [accountBalancePath],
+    outputPath
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.summary.metrics.usageExportWindowCount, 1);
+  assert.equal(result.report.summary.metrics.usageExportCreditsReported, 10559.88);
+  assert.equal(result.report.summary.metrics.accountBalanceRemainingCredits, 11700);
+  assert.equal(result.report.summary.provenance.usageExports.length, 1);
+  assert.equal(result.report.summary.provenance.accountBalance?.planName, 'Business');
 });
 
 test('runAgentCostRollup aggregates exact and estimated turn spend with provenance', () => {

--- a/tools/priority/__tests__/agent-cost-turn.test.mjs
+++ b/tools/priority/__tests__/agent-cost-turn.test.mjs
@@ -9,76 +9,112 @@ import { spawnSync } from 'node:child_process';
 
 import { buildAgentCostTurn, parseArgs, runAgentCostTurn } from '../agent-cost-turn.mjs';
 
+function withEnv(updates, callback) {
+  const original = new Map();
+  for (const [key, value] of Object.entries(updates)) {
+    original.set(key, process.env[key]);
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    for (const [key, value] of original.entries()) {
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 test('parseArgs captures reasoning-effort metadata and derives effective defaults', () => {
-  const parsed = parseArgs([
-    'node',
-    'agent-cost-turn.mjs',
-    '--provider-id', 'codex-cli',
-    '--provider-kind', 'local-codex',
-    '--provider-runtime', 'codex-cli',
-    '--execution-plane', 'wsl2',
-    '--requested-model', 'gpt-5.4',
-    '--requested-reasoning-effort', 'xhigh',
-    '--repository', 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-    '--issue-number', '1644',
-    '--lane-id', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    '--lane-branch', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    '--session-id', 'session-live-1644',
-    '--turn-id', 'turn-live-1644',
-    '--agent-role', 'live',
-    '--source-schema', 'priority/manual-live-session@v1',
-    '--usage-observed-at', '2026-03-21T18:40:00.000Z'
-  ]);
+  const parsed = withEnv(
+    {
+      GITHUB_HEAD_REF: 'issue/origin-1644-reasoning-effort-model-selection-telemetry'
+    },
+    () =>
+      parseArgs([
+        'node',
+        'agent-cost-turn.mjs',
+        '--provider-id', 'codex-cli',
+        '--provider-kind', 'local-codex',
+        '--provider-runtime', 'codex-cli',
+        '--execution-plane', 'wsl2',
+        '--requested-model', 'gpt-5.4',
+        '--requested-reasoning-effort', 'xhigh',
+        '--repository', 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        '--issue-number', '1644',
+        '--lane-id', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
+        '--session-id', 'session-live-1644',
+        '--turn-id', 'turn-live-1644',
+        '--agent-role', 'live',
+        '--source-schema', 'priority/manual-live-session@v1',
+        '--usage-observed-at', '2026-03-21T18:40:00.000Z'
+      ])
+  );
 
   assert.equal(parsed.effectiveModel, 'gpt-5.4');
   assert.equal(parsed.requestedReasoningEffort, 'xhigh');
   assert.equal(parsed.effectiveReasoningEffort, 'xhigh');
   assert.equal(parsed.usageUnitCount, 1);
   assert.equal(parsed.operatorSteered, false);
+  assert.equal(parsed.laneBranch, 'issue/origin-1644-reasoning-effort-model-selection-telemetry');
 });
 
 test('buildAgentCostTurn writes a normalized receipt with reasoning effort and steering metadata', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-turn-'));
   const outputPath = path.join(tmpDir, 'turn.json');
-  const result = buildAgentCostTurn({
-    providerId: 'codex-cli',
-    providerKind: 'local-codex',
-    providerRuntime: 'codex-cli',
-    executionPlane: 'wsl2',
-    requestedModel: 'gpt-5.4',
-    effectiveModel: 'gpt-5.4',
-    requestedReasoningEffort: 'xhigh',
-    effectiveReasoningEffort: 'xhigh',
-    inputTokens: 1000,
-    cachedInputTokens: 0,
-    outputTokens: 250,
-    usageUnitKind: 'turn',
-    usageUnitCount: 1,
-    exactness: 'estimated',
-    amountUsd: 0.05,
-    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-    issueNumber: 1644,
-    laneId: 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    laneBranch: 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    sessionId: 'session-live-1644',
-    turnId: 'turn-live-1644',
-    workerSlotId: 'worker-slot-1',
-    agentRole: 'live',
-    sourceSchema: 'priority/manual-live-session@v1',
-    sourceReceiptPath: 'tests/results/_agent/runtime/live-turn-1644.json',
-    sourceReportPath: null,
-    usageObservedAt: '2026-03-21T18:40:00.000Z',
-    operatorSteered: true,
-    operatorSteeringKind: 'operator-prompt',
-    operatorSteeringSource: 'operator-observed',
-    operatorSteeringObservedAt: '2026-03-21T18:39:30.000Z',
-    operatorSteeringNote: 'Operator provided extra steering for this calibration turn.',
-    steeringInvoiceTurnId: 'invoice-turn-2026-03-HQ1VJLMV-0027',
-    outputPath
-  }, new Date('2026-03-21T18:41:00.000Z'));
+  const result = withEnv(
+    {
+      GITHUB_HEAD_REF: 'issue/origin-1644-reasoning-effort-model-selection-telemetry'
+    },
+    () =>
+      buildAgentCostTurn({
+        providerId: 'codex-cli',
+        providerKind: 'local-codex',
+        providerRuntime: 'codex-cli',
+        executionPlane: 'wsl2',
+        requestedModel: 'gpt-5.4',
+        effectiveModel: 'gpt-5.4',
+        requestedReasoningEffort: 'xhigh',
+        effectiveReasoningEffort: 'xhigh',
+        inputTokens: 1000,
+        cachedInputTokens: 0,
+        outputTokens: 250,
+        usageUnitKind: 'turn',
+        usageUnitCount: 1,
+        exactness: 'estimated',
+        amountUsd: 0.05,
+        repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        issueNumber: 1644,
+        laneId: 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
+        sessionId: 'session-live-1644',
+        turnId: 'turn-live-1644',
+        workerSlotId: 'worker-slot-1',
+        agentRole: 'live',
+        sourceSchema: 'priority/manual-live-session@v1',
+        sourceReceiptPath: 'tests/results/_agent/runtime/live-turn-1644.json',
+        sourceReportPath: null,
+        usageObservedAt: '2026-03-21T18:40:00.000Z',
+        operatorSteered: true,
+        operatorSteeringKind: 'operator-prompt',
+        operatorSteeringSource: 'operator-observed',
+        operatorSteeringObservedAt: '2026-03-21T18:39:30.000Z',
+        operatorSteeringNote: 'Operator provided extra steering for this calibration turn.',
+        steeringInvoiceTurnId: 'invoice-turn-2026-03-HQ1VJLMV-0027',
+        outputPath
+      }, new Date('2026-03-21T18:41:00.000Z'))
+  );
 
   assert.equal(result.report.model.requestedReasoningEffort, 'xhigh');
   assert.equal(result.report.model.effectiveReasoningEffort, 'xhigh');
+  assert.equal(result.report.context.laneBranch, 'issue/origin-1644-reasoning-effort-model-selection-telemetry');
   assert.equal(result.report.steering.operatorIntervened, true);
   assert.equal(result.report.steering.kind, 'operator-prompt');
   assert.equal(result.report.steering.invoiceTurnId, 'invoice-turn-2026-03-HQ1VJLMV-0027');
@@ -105,7 +141,6 @@ test('agent-cost-turn CLI writes a receipt directly', () => {
       '--repository', 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
       '--issue-number', '1644',
       '--lane-id', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-      '--lane-branch', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
       '--session-id', 'session-live-1644',
       '--turn-id', 'turn-live-1644',
       '--agent-role', 'live',
@@ -118,6 +153,10 @@ test('agent-cost-turn CLI writes a receipt directly', () => {
     ],
     {
       cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_HEAD_REF: 'issue/origin-1644-reasoning-effort-model-selection-telemetry'
+      },
       encoding: 'utf8'
     }
   );
@@ -126,6 +165,7 @@ test('agent-cost-turn CLI writes a receipt directly', () => {
   assert.match(result.stdout, /\[agent-cost-turn\] wrote /);
   assert.equal(fs.existsSync(outputPath), true);
   const output = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.equal(output.context.laneBranch, 'issue/origin-1644-reasoning-effort-model-selection-telemetry');
   assert.equal(output.steering.operatorIntervened, true);
   assert.equal(output.steering.kind, 'operator-prompt');
 });

--- a/tools/priority/agent-cost-account-balance-normalize.mjs
+++ b/tools/priority/agent-cost-account-balance-normalize.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 export const INPUT_SCHEMA = 'priority/agent-cost-private-account-balance@v1';
 export const REPORT_SCHEMA = 'priority/agent-cost-account-balance@v1';
-export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'cost', 'agent-cost-account-balance.json');
+export const DEFAULT_OUTPUT_DIRECTORY = path.join('tests', 'results', '_agent', 'cost', 'account-balances');
 
 const CONFIDENCE_LEVELS = new Set(['low', 'medium', 'high']);
 
@@ -38,6 +38,14 @@ function normalizeDate(value) {
   return Number.isFinite(parsed) ? new Date(parsed).toISOString().slice(0, 10) : '';
 }
 
+function toUtcMidnightDateTime(value) {
+  const text = normalizeDate(value);
+  if (!text) {
+    return '';
+  }
+  return `${text}T00:00:00.000Z`;
+}
+
 function normalizeConfidence(value) {
   const text = normalizeText(value).toLowerCase();
   return CONFIDENCE_LEVELS.has(text) ? text : '';
@@ -52,9 +60,9 @@ function toNonNegativeInteger(value) {
 }
 
 function deriveBalanceTotals(payload) {
-  let total = toNonNegativeInteger(payload?.credits?.total ?? payload?.totalCredits);
-  let used = toNonNegativeInteger(payload?.credits?.used ?? payload?.usedCredits);
-  let remaining = toNonNegativeInteger(payload?.credits?.remaining ?? payload?.remainingCredits);
+  let total = toNonNegativeInteger(payload?.balances?.totalCredits ?? payload?.credits?.total ?? payload?.totalCredits);
+  let used = toNonNegativeInteger(payload?.balances?.usedCredits ?? payload?.credits?.used ?? payload?.usedCredits);
+  let remaining = toNonNegativeInteger(payload?.balances?.remainingCredits ?? payload?.credits?.remaining ?? payload?.remainingCredits);
 
   if (total == null && used != null && remaining != null) {
     total = used + remaining;
@@ -116,8 +124,13 @@ function validateInputPayload(payload) {
     throw new Error('Account balance payload must include plan.renewsAt.');
   }
 
-  if (!normalizeText(payload.sourcePath) && !normalizeText(payload?.provenance?.sourcePath)) {
-    throw new Error('Account balance payload must include sourcePath.');
+  if (
+    !normalizeText(payload.sourcePathEvidence) &&
+    !normalizeText(payload.sourcePath) &&
+    !normalizeText(payload?.provenance?.sourcePathEvidence) &&
+    !normalizeText(payload?.provenance?.sourcePath)
+  ) {
+    throw new Error('Account balance payload must include sourcePathEvidence.');
   }
 }
 
@@ -172,9 +185,17 @@ export function buildNormalizedAccountBalanceReceiptFromSnapshot(snapshotPayload
     throw new Error('Account balance payload snapshotAt must be a valid date-time.');
   }
 
+  const capturedAt = normalizeDateTime(snapshotPayload.capturedAt) || snapshotAt;
+  const effectiveAt = normalizeDateTime(snapshotPayload.effectiveAt) || snapshotAt;
+
   const renewsAt = normalizeDate(snapshotPayload?.plan?.renewsAt ?? snapshotPayload?.renewsAt);
   if (!renewsAt) {
     throw new Error('Account balance payload plan.renewsAt must be a valid date.');
+  }
+
+  const renewalCycleBoundaryAt = toUtcMidnightDateTime(renewsAt);
+  if (!renewalCycleBoundaryAt) {
+    throw new Error('Account balance payload plan.renewsAt must resolve to a cycle boundary.');
   }
 
   const credits = deriveBalanceTotals(snapshotPayload);
@@ -184,38 +205,68 @@ export function buildNormalizedAccountBalanceReceiptFromSnapshot(snapshotPayload
   }
 
   const confidence = normalizeConfidence(snapshotPayload?.provenance?.confidence ?? snapshotPayload.confidence) || 'high';
-  const sourcePath = normalizeText(snapshotPayload.sourcePath) || normalizeText(snapshotPayload?.provenance?.sourcePath);
+  const sourceSchema = normalizeText(snapshotPayload?.sourceSchema ?? snapshotPayload?.provenance?.sourceSchema) || INPUT_SCHEMA;
+  const sourceKind = normalizeText(snapshotPayload?.sourceKind ?? snapshotPayload?.provenance?.sourceKind) || 'operator-account-state';
+  const sourcePathEvidence =
+    normalizeText(snapshotPayload.sourcePathEvidence) ||
+    normalizeText(snapshotPayload.sourcePath) ||
+    normalizeText(snapshotPayload?.provenance?.sourcePathEvidence) ||
+    normalizeText(snapshotPayload?.provenance?.sourcePath);
+  const operatorNote =
+    normalizeText(snapshotPayload.operatorNote) ||
+    normalizeText(snapshotPayload?.provenance?.operatorNote) ||
+    'Normalized from a local private account balance snapshot.';
   const generatedAt = normalizeDateTime(options.generatedAt) || new Date().toISOString();
 
   return {
     schema: REPORT_SCHEMA,
     generatedAt,
+    effectiveAt,
     snapshotAt,
+    capturedAt,
+    renewalCycleBoundaryAt,
     plan: {
       name: normalizeText(snapshotPayload?.plan?.name) || 'business',
       renewsAt,
       daysRemaining: cycleDaysRemaining
     },
-    credits,
-    provenance: {
-      sourceSchema: normalizeText(snapshotPayload.schema) || INPUT_SCHEMA,
-      sourceKind: normalizeText(snapshotPayload?.provenance?.sourceKind) || 'operator-account-state',
-      sourcePath,
-      observedAt: normalizeDateTime(snapshotPayload?.provenance?.observedAt) || snapshotAt,
-      confidence,
-      operatorNote:
-        normalizeText(snapshotPayload?.provenance?.operatorNote) ||
-        'Normalized from a local private account balance snapshot.'
-    }
+    balances: {
+      totalCredits: credits.total,
+      usedCredits: credits.used,
+      remainingCredits: credits.remaining
+    },
+    sourceSchema,
+    sourceKind,
+    sourcePathEvidence,
+    confidence,
+    operatorNote
   };
+}
+
+function deriveDefaultOutputPath(report) {
+  const effectiveDate = normalizeDate(report?.effectiveAt) || normalizeDate(report?.capturedAt) || normalizeDate(report?.snapshotAt);
+  if (!effectiveDate) {
+    throw new Error('Normalized account balance receipts must include an effectiveAt, capturedAt, or snapshotAt date.');
+  }
+  return path.join(DEFAULT_OUTPUT_DIRECTORY, `account-balance-${effectiveDate}.json`);
 }
 
 export function runAgentCostAccountBalanceNormalize(options) {
   const snapshot = readSnapshot(options.snapshotPath);
-  const report = buildNormalizedAccountBalanceReceiptFromSnapshot(snapshot.payload, {
+  const payload = {
+    ...snapshot.payload,
+    sourcePathEvidence:
+      normalizeText(snapshot.payload?.sourcePathEvidence) ||
+      normalizeText(snapshot.payload?.sourcePath) ||
+      normalizeText(snapshot.payload?.provenance?.sourcePathEvidence) ||
+      normalizeText(snapshot.payload?.provenance?.sourcePath) ||
+      snapshot.resolved
+  };
+  const report = buildNormalizedAccountBalanceReceiptFromSnapshot(payload, {
     generatedAt: options.generatedAt
   });
-  const outputPath = path.resolve(options.outputPath || DEFAULT_OUTPUT_PATH);
+  const defaultOutputPath = deriveDefaultOutputPath(report);
+  const outputPath = path.resolve(options.outputPath || defaultOutputPath);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   return {
@@ -230,7 +281,9 @@ function printUsage() {
   console.log('');
   console.log('Options:');
   console.log(`  --snapshot <path>   Local private account balance snapshot JSON (${INPUT_SCHEMA}) (required).`);
-  console.log('  --output <path>     Optional account-balance receipt output override.');
+  console.log(
+    '  --output <path>     Optional account-balance receipt output override (defaults to tests/results/_agent/cost/account-balances/account-balance-<YYYY-MM-DD>.json).'
+  );
   console.log('  -h, --help          Show help and exit.');
 }
 

--- a/tools/priority/agent-cost-rollup.mjs
+++ b/tools/priority/agent-cost-rollup.mjs
@@ -6,9 +6,13 @@ import { execSync } from 'node:child_process';
 
 export const TURN_SCHEMA = 'priority/agent-cost-turn@v1';
 export const INVOICE_TURN_SCHEMA = 'priority/agent-cost-invoice-turn@v1';
+export const USAGE_EXPORT_SCHEMA = 'priority/agent-cost-usage-export@v1';
+export const ACCOUNT_BALANCE_SCHEMA = 'priority/agent-cost-account-balance@v1';
 export const REPORT_SCHEMA = 'priority/agent-cost-rollup@v1';
 export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'cost', 'agent-cost-rollup.json');
 export const DEFAULT_INVOICE_TURN_DIR = path.join('tests', 'results', '_agent', 'cost', 'invoice-turns');
+export const DEFAULT_USAGE_EXPORT_DIR = path.join('tests', 'results', '_agent', 'cost', 'usage-exports');
+export const DEFAULT_ACCOUNT_BALANCE_DIR = path.join('tests', 'results', '_agent', 'cost', 'account-balances');
 
 function normalizeText(value) {
   if (value == null) {
@@ -381,6 +385,164 @@ function discoverInvoiceTurnPaths() {
     .sort((left, right) => left.localeCompare(right));
 }
 
+function discoverJsonPaths(directoryPath) {
+  const resolvedDirectory = path.resolve(directoryPath);
+  if (!fs.existsSync(resolvedDirectory)) {
+    return [];
+  }
+  return fs
+    .readdirSync(resolvedDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.json'))
+    .map((entry) => path.join(resolvedDirectory, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeUsageExportReceipt(input) {
+  if (!input) {
+    return {
+      status: 'missing',
+      blockers: []
+    };
+  }
+  const payload = input?.payload;
+  if (!payload || typeof payload !== 'object') {
+    return {
+      status: 'invalid',
+      blockers: [createBlocker('usage-export-unreadable', 'Usage export receipt could not be read as JSON.', input.path)]
+    };
+  }
+  if (normalizeText(payload.schema) !== USAGE_EXPORT_SCHEMA) {
+    return {
+      status: 'invalid',
+      blockers: [
+        createBlocker(
+          'usage-export-schema-mismatch',
+          `Usage export receipt schema must remain ${USAGE_EXPORT_SCHEMA}.`,
+          input.path
+        )
+      ]
+    };
+  }
+
+  const startDate = normalizeText(payload?.reportWindow?.startDate) || null;
+  const endDate = normalizeText(payload?.reportWindow?.endDate) || null;
+  const rowCount = toNonNegativeInteger(payload?.reportWindow?.rowCount);
+  const usageCredits = toNonNegativeNumber(payload?.totals?.usageCredits);
+  const usageQuantity = toNonNegativeNumber(payload?.totals?.usageQuantity);
+  const blockers = [];
+  if (!startDate) {
+    blockers.push(createBlocker('usage-export-start-date-missing', 'Usage export reportWindow.startDate is required.', input.path));
+  }
+  if (!endDate) {
+    blockers.push(createBlocker('usage-export-end-date-missing', 'Usage export reportWindow.endDate is required.', input.path));
+  }
+  if (usageCredits == null) {
+    blockers.push(createBlocker('usage-export-credits-missing', 'Usage export totals.usageCredits is required.', input.path));
+  }
+  if (usageQuantity == null) {
+    blockers.push(createBlocker('usage-export-quantity-missing', 'Usage export totals.usageQuantity is required.', input.path));
+  }
+  if (blockers.length > 0) {
+    return {
+      status: 'invalid',
+      blockers
+    };
+  }
+
+  return {
+    status: 'valid',
+    blockers: [],
+    usageExport: {
+      sourcePath: safeRelative(input.path),
+      generatedAt: normalizeDateTime(payload?.generatedAt),
+      startDate,
+      endDate,
+      rowCount,
+      usageType: normalizeText(payload?.usageType) || null,
+      usageCredits,
+      usageQuantity,
+      sourceKind: normalizeText(payload?.sourceKind) || normalizeText(payload?.provenance?.sourceKind) || null,
+      sourcePathEvidence: normalizeText(payload?.sourcePathEvidence) || normalizeText(payload?.provenance?.sourcePath) || null,
+      operatorNote: normalizeText(payload?.operatorNote) || normalizeText(payload?.provenance?.operatorNote) || null
+    }
+  };
+}
+
+function normalizeAccountBalanceReceipt(input) {
+  if (!input) {
+    return {
+      status: 'missing',
+      blockers: []
+    };
+  }
+  const payload = input?.payload;
+  if (!payload || typeof payload !== 'object') {
+    return {
+      status: 'invalid',
+      blockers: [createBlocker('account-balance-unreadable', 'Account balance receipt could not be read as JSON.', input.path)]
+    };
+  }
+  if (normalizeText(payload.schema) !== ACCOUNT_BALANCE_SCHEMA) {
+    return {
+      status: 'invalid',
+      blockers: [
+        createBlocker(
+          'account-balance-schema-mismatch',
+          `Account balance receipt schema must remain ${ACCOUNT_BALANCE_SCHEMA}.`,
+          input.path
+        )
+      ]
+    };
+  }
+
+  const snapshotAt = normalizeDateTime(payload?.effectiveAt) || normalizeDateTime(payload?.capturedAt);
+  const renewsAt = normalizeDateTime(payload?.plan?.renewsAt);
+  const totalCredits = toNonNegativeNumber(payload?.balances?.totalCredits);
+  const usedCredits = toNonNegativeNumber(payload?.balances?.usedCredits);
+  const remainingCredits = toNonNegativeNumber(payload?.balances?.remainingCredits);
+  const blockers = [];
+  if (!snapshotAt) {
+    blockers.push(
+      createBlocker('account-balance-snapshot-missing', 'Account balance effectiveAt or capturedAt is required.', input.path)
+    );
+  }
+  if (totalCredits == null) {
+    blockers.push(createBlocker('account-balance-total-missing', 'Account balance balances.totalCredits is required.', input.path));
+  }
+  if (usedCredits == null) {
+    blockers.push(createBlocker('account-balance-used-missing', 'Account balance balances.usedCredits is required.', input.path));
+  }
+  if (remainingCredits == null) {
+    blockers.push(
+      createBlocker('account-balance-remaining-missing', 'Account balance balances.remainingCredits is required.', input.path)
+    );
+  }
+  if (blockers.length > 0) {
+    return {
+      status: 'invalid',
+      blockers
+    };
+  }
+
+  return {
+    status: 'valid',
+    blockers: [],
+    accountBalance: {
+      sourcePath: safeRelative(input.path),
+      generatedAt: normalizeDateTime(payload?.generatedAt),
+      snapshotAt,
+      planName: normalizeText(payload?.plan?.name) || null,
+      renewsAt,
+      totalCredits,
+      usedCredits,
+      remainingCredits,
+      sourceKind: normalizeText(payload?.sourceKind) || normalizeText(payload?.provenance?.sourceKind) || null,
+      sourcePathEvidence: normalizeText(payload?.sourcePathEvidence) || normalizeText(payload?.provenance?.sourcePath) || null,
+      operatorNote: normalizeText(payload?.operatorNote) || normalizeText(payload?.provenance?.operatorNote) || null
+    }
+  };
+}
+
 function toTimestamp(value) {
   const normalized = normalizeDateTime(value);
   if (!normalized) {
@@ -571,6 +733,8 @@ export function parseArgs(argv = process.argv) {
   const options = {
     turnReportPaths: [],
     invoiceTurnPaths: [],
+    usageExportPaths: [],
+    accountBalancePaths: [],
     invoiceTurnId: null,
     outputPath: DEFAULT_OUTPUT_PATH,
     repo: null,
@@ -594,7 +758,15 @@ export function parseArgs(argv = process.argv) {
       options.failOnInvalidInputs = true;
       continue;
     }
-    if (token === '--turn-report' || token === '--invoice-turn' || token === '--invoice-turn-id' || token === '--output' || token === '--repo') {
+    if (
+      token === '--turn-report' ||
+      token === '--invoice-turn' ||
+      token === '--usage-export' ||
+      token === '--account-balance' ||
+      token === '--invoice-turn-id' ||
+      token === '--output' ||
+      token === '--repo'
+    ) {
       if (!next || next.startsWith('-')) {
         throw new Error(`Missing value for ${token}.`);
       }
@@ -603,6 +775,10 @@ export function parseArgs(argv = process.argv) {
         options.turnReportPaths.push(next);
       } else if (token === '--invoice-turn') {
         options.invoiceTurnPaths.push(next);
+      } else if (token === '--usage-export') {
+        options.usageExportPaths.push(next);
+      } else if (token === '--account-balance') {
+        options.accountBalancePaths.push(next);
       } else if (token === '--invoice-turn-id') {
         options.invoiceTurnId = next;
       } else if (token === '--output') {
@@ -620,6 +796,12 @@ export function parseArgs(argv = process.argv) {
   }
   if (!options.help && options.invoiceTurnPaths.length === 0) {
     options.invoiceTurnPaths = discoverInvoiceTurnPaths();
+  }
+  if (!options.help && options.usageExportPaths.length === 0) {
+    options.usageExportPaths = discoverJsonPaths(DEFAULT_USAGE_EXPORT_DIR);
+  }
+  if (!options.help && options.accountBalancePaths.length === 0) {
+    options.accountBalancePaths = discoverJsonPaths(DEFAULT_ACCOUNT_BALANCE_DIR);
   }
   return options;
 }
@@ -667,8 +849,14 @@ export function runAgentCostRollup(options) {
   const normalizedTurns = turnInputs.map((input) => normalizeTurnReceipt(input));
   const invoiceTurnInputs = ensureArray(options.invoiceTurnPaths).map((filePath) => loadInputFile(filePath));
   const normalizedInvoiceTurns = invoiceTurnInputs.map((input) => normalizeInvoiceTurnReceipt(input));
+  const usageExportInputs = ensureArray(options.usageExportPaths).map((filePath) => loadInputFile(filePath));
+  const normalizedUsageExports = usageExportInputs.map((input) => normalizeUsageExportReceipt(input));
+  const accountBalanceInputs = ensureArray(options.accountBalancePaths).map((filePath) => loadInputFile(filePath));
+  const normalizedAccountBalances = accountBalanceInputs.map((input) => normalizeAccountBalanceReceipt(input));
   const evaluation = evaluateAgentCostRollup({ turnInputs, normalizedTurns });
   const invoiceTurnBlockers = [];
+  const usageExportBlockers = [];
+  const accountBalanceBlockers = [];
   for (const invoiceTurnInput of invoiceTurnInputs) {
     if (invoiceTurnInput?.exists === false) {
       invoiceTurnBlockers.push(createBlocker('invoice-turn-missing', 'Invoice turn report is missing.', invoiceTurnInput.path));
@@ -683,8 +871,51 @@ export function runAgentCostRollup(options) {
   for (const normalizedInvoiceTurn of normalizedInvoiceTurns) {
     invoiceTurnBlockers.push(...ensureArray(normalizedInvoiceTurn.blockers));
   }
+  for (const usageExportInput of usageExportInputs) {
+    if (usageExportInput?.exists === false) {
+      usageExportBlockers.push(createBlocker('usage-export-missing', 'Usage export receipt is missing.', usageExportInput.path));
+      continue;
+    }
+    if (usageExportInput?.error) {
+      usageExportBlockers.push(
+        createBlocker('usage-export-unreadable', `Usage export receipt could not be parsed: ${usageExportInput.error}`, usageExportInput.path)
+      );
+    }
+  }
+  for (const normalizedUsageExport of normalizedUsageExports) {
+    usageExportBlockers.push(...ensureArray(normalizedUsageExport.blockers));
+  }
+  for (const accountBalanceInput of accountBalanceInputs) {
+    if (accountBalanceInput?.exists === false) {
+      accountBalanceBlockers.push(createBlocker('account-balance-missing', 'Account balance receipt is missing.', accountBalanceInput.path));
+      continue;
+    }
+    if (accountBalanceInput?.error) {
+      accountBalanceBlockers.push(
+        createBlocker(
+          'account-balance-unreadable',
+          `Account balance receipt could not be parsed: ${accountBalanceInput.error}`,
+          accountBalanceInput.path
+        )
+      );
+    }
+  }
+  for (const normalizedAccountBalance of normalizedAccountBalances) {
+    accountBalanceBlockers.push(...ensureArray(normalizedAccountBalance.blockers));
+  }
 
   const validTurns = evaluation.validTurns;
+  const validUsageExports = normalizedUsageExports.filter((entry) => entry.status === 'valid').map((entry) => entry.usageExport);
+  const validAccountBalances = normalizedAccountBalances.filter((entry) => entry.status === 'valid').map((entry) => entry.accountBalance);
+  const selectedAccountBalance =
+    [...validAccountBalances].sort((left, right) => {
+      const leftSnapshot = toTimestamp(left.snapshotAt) ?? 0;
+      const rightSnapshot = toTimestamp(right.snapshotAt) ?? 0;
+      if (rightSnapshot !== leftSnapshot) {
+        return rightSnapshot - leftSnapshot;
+      }
+      return (right.sourcePath || '').localeCompare(left.sourcePath || '');
+    })[0] ?? null;
   const invoiceTurnSelection = selectInvoiceTurn(normalizedInvoiceTurns, validTurns, options.invoiceTurnId);
   const invoiceTurn = invoiceTurnSelection.selectedInvoiceTurn;
   if (normalizeText(options.invoiceTurnId) && !invoiceTurn) {
@@ -708,6 +939,8 @@ export function runAgentCostRollup(options) {
   const unsteeredTurns = validTurns.filter((entry) => entry.operatorIntervened !== true);
   const steeredUsd = sum(steeredTurns.map((entry) => entry.amountUsd));
   const unsteeredUsd = sum(unsteeredTurns.map((entry) => entry.amountUsd));
+  const usageExportCreditsReported = sum(validUsageExports.map((entry) => entry.usageCredits));
+  const usageExportQuantityReported = sum(validUsageExports.map((entry) => entry.usageQuantity));
 
   const byProviderCount = new Map();
   const byProviderUsd = new Map();
@@ -822,18 +1055,33 @@ export function runAgentCostRollup(options) {
         exists: entry.exists,
         error: entry.error ?? null
       })),
+      usageExportPaths: usageExportInputs.map((entry) => ({
+        path: safeRelative(entry.path),
+        exists: entry.exists,
+        error: entry.error ?? null
+      })),
+      accountBalancePaths: accountBalanceInputs.map((entry) => ({
+        path: safeRelative(entry.path),
+        exists: entry.exists,
+        error: entry.error ?? null
+      })),
       selectedInvoiceTurnId: invoiceTurnSelection.selection.selectedInvoiceTurnId,
       explicitInvoiceTurnId: normalizeText(options.invoiceTurnId) || null
     },
     turns: validTurns,
     summary: {
-      status: evaluation.blockerCount + invoiceTurnBlockers.length === 0 ? evaluation.status : 'fail',
+      status:
+        evaluation.blockerCount + invoiceTurnBlockers.length + usageExportBlockers.length + accountBalanceBlockers.length === 0
+          ? evaluation.status
+          : 'fail',
       recommendation:
         invoiceTurnBlockers.length > 0
           ? 'repair-invoice-turn-baseline'
+          : usageExportBlockers.length + accountBalanceBlockers.length > 0
+            ? 'repair-input-receipts'
           : evaluation.recommendation,
-      blockerCount: evaluation.blockerCount + invoiceTurnBlockers.length,
-      blockers: [...evaluation.blockers, ...invoiceTurnBlockers],
+      blockerCount: evaluation.blockerCount + invoiceTurnBlockers.length + usageExportBlockers.length + accountBalanceBlockers.length,
+      blockers: [...evaluation.blockers, ...invoiceTurnBlockers, ...usageExportBlockers, ...accountBalanceBlockers],
       metrics: {
         totalTurns: validTurns.length,
         exactTurnCount: evaluation.exactTurns.length,
@@ -858,7 +1106,13 @@ export function runAgentCostRollup(options) {
         actualCreditsConsumed,
         heuristicUsdDelta,
         heuristicUsdDeltaRatio,
-        heuristicCreditsDelta
+        heuristicCreditsDelta,
+        usageExportWindowCount: validUsageExports.length,
+        usageExportCreditsReported,
+        usageExportQuantityReported,
+        accountBalanceTotalCredits: selectedAccountBalance?.totalCredits ?? null,
+        accountBalanceUsedCredits: selectedAccountBalance?.usedCredits ?? null,
+        accountBalanceRemainingCredits: selectedAccountBalance?.remainingCredits ?? null
       },
       provenance: {
         sessionIds: [...sessionIds].sort(),
@@ -876,7 +1130,11 @@ export function runAgentCostRollup(options) {
         invoiceTurns: normalizedInvoiceTurns
           .filter((entry) => entry.status === 'valid')
           .map((entry) => entry.invoiceTurn)
-          .sort((left, right) => (left.invoiceTurnId || '').localeCompare(right.invoiceTurnId || ''))
+          .sort((left, right) => (left.invoiceTurnId || '').localeCompare(right.invoiceTurnId || '')),
+        usageExports: validUsageExports.sort((left, right) =>
+          `${left.startDate || ''}|${left.endDate || ''}`.localeCompare(`${right.startDate || ''}|${right.endDate || ''}`)
+        ),
+        accountBalance: selectedAccountBalance
       }
     },
     billingWindow: invoiceTurn
@@ -930,6 +1188,8 @@ function printUsage() {
   console.log('Options:');
   console.log('  --turn-report <path>            Agent cost turn receipt path (repeatable, required).');
   console.log(`  --invoice-turn <path>           Optional invoice turn receipt path (repeatable; auto-discovers ${DEFAULT_INVOICE_TURN_DIR} when omitted).`);
+  console.log(`  --usage-export <path>           Optional usage export receipt path (repeatable; auto-discovers ${DEFAULT_USAGE_EXPORT_DIR} when omitted).`);
+  console.log(`  --account-balance <path>        Optional account balance receipt path (repeatable; auto-discovers ${DEFAULT_ACCOUNT_BALANCE_DIR} when omitted).`);
   console.log('  --invoice-turn-id <value>       Optional explicit invoice turn selection override.');
   console.log(`  --output <path>                 Output path (default: ${DEFAULT_OUTPUT_PATH}).`);
   console.log('  --repo <owner/repo>             Repository slug override.');

--- a/tools/priority/agent-cost-turn.mjs
+++ b/tools/priority/agent-cost-turn.mjs
@@ -2,6 +2,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 export const REPORT_SCHEMA = 'priority/agent-cost-turn@v1';
@@ -39,6 +40,38 @@ function normalizeReasoningEffort(value) {
 function sanitizeFileSegment(value, fallback) {
   const normalized = normalizeText(value).replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
   return normalized || fallback;
+}
+
+function resolveActiveLaneBranch(explicitLaneBranch, env = process.env, execSyncFn = execSync) {
+  const explicit = normalizeText(explicitLaneBranch);
+  if (explicit) {
+    return explicit;
+  }
+
+  const headRef = normalizeText(env?.GITHUB_HEAD_REF);
+  if (headRef) {
+    return headRef;
+  }
+
+  const refName = normalizeText(env?.GITHUB_REF_NAME);
+  if (refName && refName !== 'merge') {
+    return refName;
+  }
+
+  try {
+    const currentBranch = normalizeText(
+      execSyncFn('git branch --show-current', {
+        stdio: ['ignore', 'pipe', 'ignore']
+      }).toString('utf8')
+    );
+    if (currentBranch) {
+      return currentBranch;
+    }
+  } catch {
+    // Ignore git fallback failures and surface a clear validation error below.
+  }
+
+  return '';
 }
 
 export function parseArgs(argv = process.argv) {
@@ -213,7 +246,6 @@ export function parseArgs(argv = process.argv) {
     ['requestedModel', '--requested-model'],
     ['repository', '--repository'],
     ['laneId', '--lane-id'],
-    ['laneBranch', '--lane-branch'],
     ['sessionId', '--session-id'],
     ['turnId', '--turn-id'],
     ['agentRole', '--agent-role'],
@@ -230,6 +262,7 @@ export function parseArgs(argv = process.argv) {
     throw new Error('Missing required option: --issue-number <integer>.');
   }
 
+  options.laneBranch = resolveActiveLaneBranch(options.laneBranch);
   options.inputTokens = toNonNegativeInteger(options.inputTokens) ?? 0;
   options.cachedInputTokens = toNonNegativeInteger(options.cachedInputTokens) ?? 0;
   options.outputTokens = toNonNegativeInteger(options.outputTokens) ?? 0;
@@ -246,6 +279,9 @@ export function parseArgs(argv = process.argv) {
   }
   if (!['live', 'background'].includes(normalizeText(options.agentRole).toLowerCase())) {
     throw new Error('agent-role must be live or background.');
+  }
+  if (!normalizeText(options.laneBranch)) {
+    throw new Error('Missing required option: --lane-branch <value> or a resolvable active branch.');
   }
 
   options.effectiveModel = normalizeText(options.effectiveModel) || normalizeText(options.requestedModel);
@@ -270,6 +306,7 @@ export function buildAgentCostTurn(options, now = new Date()) {
   const normalizedRequestedReasoningEffort = normalizeReasoningEffort(options.requestedReasoningEffort);
   const normalizedEffectiveReasoningEffort =
     normalizeReasoningEffort(options.effectiveReasoningEffort) ?? normalizedRequestedReasoningEffort;
+  const resolvedLaneBranch = resolveActiveLaneBranch(options.laneBranch);
   const normalizedInputTokens = toNonNegativeInteger(options.inputTokens) ?? 0;
   const normalizedCachedInputTokens = toNonNegativeInteger(options.cachedInputTokens) ?? 0;
   const normalizedOutputTokens = toNonNegativeInteger(options.outputTokens) ?? 0;
@@ -357,7 +394,7 @@ export function buildAgentCostTurn(options, now = new Date()) {
       repository: normalizeText(options.repository),
       issueNumber: options.issueNumber,
       laneId: normalizeText(options.laneId),
-      laneBranch: normalizeText(options.laneBranch),
+      laneBranch: resolvedLaneBranch,
       sessionId: normalizeText(options.sessionId),
       turnId: normalizeText(options.turnId),
       workerSlotId: normalizeText(options.workerSlotId) || null,
@@ -404,7 +441,7 @@ function printUsage() {
   console.log('  --repository <owner/repo>');
   console.log('  --issue-number <integer>');
   console.log('  --lane-id <value>');
-  console.log('  --lane-branch <value>');
+  console.log('  --lane-branch <value>    Optional; defaults to GITHUB_HEAD_REF or the current git branch.');
   console.log('  --session-id <value>');
   console.log('  --turn-id <value>');
   console.log('  --agent-role <live|background>');


### PR DESCRIPTION
## Summary

Emit branch-attributed cost turns for active PR lanes so PR spend projection prefers branch matches over linked-issue fallback.

## Validation

- node --test tools/priority/__tests__/agent-cost-turn.test.mjs
- git diff --check

Closes #1682